### PR TITLE
don't publish to test in python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,16 +21,6 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
 
-    # - name: Configure Poetry for TestPyPI
-    #   run: >-
-    #     poetry config repositories.testpypi https://test.pypi.org/legacy/
-    #     && poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
-
-    # - name: Build and publish to TestPyPI
-    #   run: >-
-    #     poetry build
-    #     && poetry publish --repository testpypi
-
     - name: Configure Poetry for PyPI
       run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,15 +21,15 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@v3
 
-    - name: Configure Poetry for TestPyPI
-      run: >-
-        poetry config repositories.testpypi https://test.pypi.org/legacy/
-        && poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
+    # - name: Configure Poetry for TestPyPI
+    #   run: >-
+    #     poetry config repositories.testpypi https://test.pypi.org/legacy/
+    #     && poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
 
-    - name: Build and publish to TestPyPI
-      run: >-
-        poetry build
-        && poetry publish --repository testpypi
+    # - name: Build and publish to TestPyPI
+    #   run: >-
+    #     poetry build
+    #     && poetry publish --repository testpypi
 
     - name: Configure Poetry for PyPI
       run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Since 1.4.1 is present in test pypi-test, we can temporarily disable it to upload package to PYPI