### PR TITLE
Add batch_size to all fingerprints

### DIFF
--- a/skfp/bases/base_substructure_fp.py
+++ b/skfp/bases/base_substructure_fp.py
@@ -39,6 +39,10 @@ class BaseSubstructureFingerprint(BaseFingerprintTransformer):
         :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
         See Scikit-learn documentation on ``n_jobs`` for more details.
 
+    batch_size : int, default=None
+        Number of inputs processed in each batch. ``None`` divides input data into
+        equal-sized parts, as many as ``n_jobs``.
+
     verbose : int, default=0
         Controls the verbosity when computing fingerprints.
 
@@ -62,6 +66,7 @@ class BaseSubstructureFingerprint(BaseFingerprintTransformer):
         count: bool = False,
         sparse: bool = False,
         n_jobs: Optional[int] = None,
+        batch_size: Optional[int] = None,
         verbose: int = 0,
         random_state: Optional[int] = 0,
     ):
@@ -70,6 +75,7 @@ class BaseSubstructureFingerprint(BaseFingerprintTransformer):
             count=count,
             sparse=sparse,
             n_jobs=n_jobs,
+            batch_size=batch_size,
             verbose=verbose,
             random_state=random_state,
         )

--- a/skfp/fingerprints/ghose_crippen.py
+++ b/skfp/fingerprints/ghose_crippen.py
@@ -32,6 +32,10 @@ class GhoseCrippenFingerprint(BaseSubstructureFingerprint):
         :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
         See Scikit-learn documentation on ``n_jobs`` for more details.
 
+    batch_size : int, default=None
+        Number of inputs processed in each batch. ``None`` divides input data into
+        equal-sized parts, as many as ``n_jobs``.
+
     verbose : int, default=0
         Controls the verbosity when computing fingerprints.
 
@@ -77,6 +81,7 @@ class GhoseCrippenFingerprint(BaseSubstructureFingerprint):
         count: bool = False,
         sparse: bool = False,
         n_jobs: Optional[int] = None,
+        batch_size: Optional[int] = None,
         verbose: int = 0,
     ):
         # flake8: noqa: E501
@@ -198,6 +203,7 @@ class GhoseCrippenFingerprint(BaseSubstructureFingerprint):
             count=count,
             sparse=sparse,
             n_jobs=n_jobs,
+            batch_size=batch_size,
             verbose=verbose,
         )
 

--- a/skfp/fingerprints/klekota_roth.py
+++ b/skfp/fingerprints/klekota_roth.py
@@ -29,6 +29,10 @@ class KlekotaRothFingerprint(BaseSubstructureFingerprint):
         :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
         See Scikit-learn documentation on ``n_jobs`` for more details.
 
+    batch_size : int, default=None
+        Number of inputs processed in each batch. ``None`` divides input data into
+        equal-sized parts, as many as ``n_jobs``.
+
     verbose : int, default=0
         Controls the verbosity when computing fingerprints.
 
@@ -67,6 +71,7 @@ class KlekotaRothFingerprint(BaseSubstructureFingerprint):
         count: bool = False,
         sparse: bool = False,
         n_jobs: Optional[int] = None,
+        batch_size: Optional[int] = None,
         verbose: int = 0,
     ):
         # flake8: noqa: E501

--- a/skfp/fingerprints/laggner.py
+++ b/skfp/fingerprints/laggner.py
@@ -33,6 +33,10 @@ class LaggnerFingerprint(BaseSubstructureFingerprint):
         :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
         See Scikit-learn documentation on ``n_jobs`` for more details.
 
+    batch_size : int, default=None
+        Number of inputs processed in each batch. ``None`` divides input data into
+        equal-sized parts, as many as ``n_jobs``.
+
     verbose : int, default=0
         Controls the verbosity when computing fingerprints.
 
@@ -76,6 +80,7 @@ class LaggnerFingerprint(BaseSubstructureFingerprint):
         count: bool = False,
         sparse: bool = False,
         n_jobs: Optional[int] = None,
+        batch_size: Optional[int] = None,
         verbose: int = 0,
     ):
         # RDKit does not support multi-component SMARTS (with a dot), so we can't match

--- a/skfp/fingerprints/maccs.py
+++ b/skfp/fingerprints/maccs.py
@@ -41,6 +41,10 @@ class MACCSFingerprint(BaseFingerprintTransformer):
         :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
         See Scikit-learn documentation on ``n_jobs`` for more details.
 
+    batch_size : int, default=None
+        Number of inputs processed in each batch. ``None`` divides input data into
+        equal-sized parts, as many as ``n_jobs``.
+
     verbose : int, default=0
         Controls the verbosity when computing fingerprints.
 


### PR DESCRIPTION
Some fingerprints were missing `batch_size` argument, this PR fixes this, including docs