### PR TITLE
Release docs with official release

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -1,12 +1,8 @@
 name: Deploy content to Pages
 
 on:
-  push:
-    branches: [ "master" ]
-    paths:
-      - 'docs/**'
-      - 'skfp/**'
-      - '.github/workflows/build-and-publish-docs.yml'
+  release:
+    types: [ published ]
 
   # allow running manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Changes

Change docs-building hook to run only on release, to avoid publishing (probably changed) docs before new version is available in PyPI.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
