### PR TITLE
Pharmacophore docs fix

### DIFF
--- a/skfp/fingerprints/pharmacophore.py
+++ b/skfp/fingerprints/pharmacophore.py
@@ -35,7 +35,7 @@ class PharmacophoreFingerprint(BaseFingerprintTransformer):
     - acidic group
 
     Those structures can be returned as raw bits, results in 39972-element vector. By
-    default, they are folded into a shorter length vector. Both 2-point and 3-point
+    default, this vector is returned, but it can also be folded. Both 2-point and 3-point
     pharmacophores (pharmacophoric pairs and triangles) are used.
 
     Parameters


### PR DESCRIPTION
## Changes

Fix a typo in pharmacophore description - raw bits are returned by default, not a folded version.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
