### PR TITLE
Docs fixes

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -73,4 +73,4 @@ jobs:
         run: poetry install --with doc
 
       - name: Build documentation
-        run: poetry run make docs
+        run: poetry run make doctest

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ docs: ## Re-generate documentation
 	-rm -r docs/modules/generated
 	poetry run $(MAKE) -C docs clean html
 
-doctest: docs ## Run doctests
-	poetry run pytest --doctest-modules skfp
+doctest: docs ## Run documentation tests
+	poetry run $(MAKE) -C docs doctest
 
 test: ## Run tests
 	poetry run black . --check --diff

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup docs test test-coverage help
+.PHONY: setup docs doctest test test-coverage help
 .DEFAULT_GOAL := help
 
 setup: ## Install development dependencies, pre-commit hooks and poetry plugin
@@ -10,7 +10,10 @@ setup: ## Install development dependencies, pre-commit hooks and poetry plugin
 
 docs: ## Re-generate documentation
 	-rm -r docs/modules/generated
-	poetry run $(MAKE) -C docs clean html doctest
+	poetry run $(MAKE) -C docs clean html
+
+doctest: docs ## Run doctests
+	poetry run pytest --doctest-modules skfp
 
 test: ## Run tests
 	poetry run black . --check --diff

--- a/docs/modules/bases.rst
+++ b/docs/modules/bases.rst
@@ -5,6 +5,7 @@ Base classes
 .. automodule:: skfp.bases
 
 :mod: `skfp.bases`: Base classes
+
 =========================================================
 
 .. py:currentmodule:: skfp.bases

--- a/docs/modules/model_selection.rst
+++ b/docs/modules/model_selection.rst
@@ -1,6 +1,6 @@
-============
+===============
 Model selection
-============
+===============
 
 .. automodule:: skfp.model_selection
 

--- a/skfp/fingerprints/getaway.py
+++ b/skfp/fingerprints/getaway.py
@@ -28,6 +28,7 @@ class GETAWAYFingerprint(BaseFingerprintTransformer):
 
     GETAWAY descriptors consist of 273 features (see [3]_ [4]_ [5]_ [6]_ for precise
     definitions):
+
     - 7 related to general molecule shape, defined only on H and R matrices
     - 7 sets of autocorrelation descriptors, each defined on topological distances
       (shortest paths) from 0 to 8 (inclusive)

--- a/skfp/preprocessing/filters/pfizer.py
+++ b/skfp/preprocessing/filters/pfizer.py
@@ -17,9 +17,8 @@ class PfizerFilter(BaseFilter):
 
     Molecule must fulfill conditions:
 
-        - logP <= 3
-        - TPSA >= 75
-
+    - logP <= 3
+    - TPSA >= 75
 
     Parameters
     ----------

--- a/skfp/preprocessing/filters/rule_of_three.py
+++ b/skfp/preprocessing/filters/rule_of_three.py
@@ -26,6 +26,7 @@ class RuleOfThree(BaseFilter):
     - HBA <= 3
     - HBD <= 3
     - logP <= 3
+
     Additionally, an extended version of this rule has been proposed, which adds two conditions:
 
     - TPSA <= 60

--- a/skfp/utils/parallel.py
+++ b/skfp/utils/parallel.py
@@ -44,7 +44,7 @@ def run_in_parallel(
     batch of data, e.g. list of integers, not a single integer.
 
     If ``func`` returns lists, the result will be a list of lists. To get a flat list
-    of results, use ``flatten_results=True`.
+    of results, use ``flatten_results=True``.
 
     Note that progress bar for ``verbose`` option tracks processing of data batches,
     not individual data points.


### PR DESCRIPTION
## Changes

* Now `make docs` does not run doctest. `make doctest` does that.
* Fixed some errors in documentation from warnings.


*Short description of changes*

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
