### PR TITLE
Expand MoleculeNet loading

### DIFF
--- a/tests/datasets/moleculenet.py
+++ b/tests/datasets/moleculenet.py
@@ -44,6 +44,21 @@ def test_load_moleculenet_benchmark():
     assert benchmark_names == dataset_names
 
 
+def test_load_moleculenet_benchmark_subset():
+    dataset_names = ["ESOL", "SIDER", "BACE"]
+    benchmark_full = load_moleculenet_benchmark(subset=dataset_names, as_frames=True)
+    benchmark_names = [name for name, df in benchmark_full]
+    assert benchmark_names == dataset_names
+
+
+def test_load_moleculenet_benchmark_wrong_subset():
+    dataset_names = ["ESOL", "Nonexistent"]
+    with pytest.raises(ValueError) as exc_info:
+        load_moleculenet_benchmark(subset=dataset_names, as_frames=True)
+
+    assert "Dataset name 'Nonexistent' not recognized" in str(exc_info)
+
+
 @pytest.mark.parametrize("dataset_name", get_dataset_names())
 def test_load_ogb_splits(dataset_name):
     train, valid, test = load_ogb_splits(dataset_name)


### PR DESCRIPTION
## Changes

Slight expansion of Moleculenet loading, making it more flexible to load subsets of datasets. Also more efficient through use of generators, rather than lists.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
