### PR TITLE
Fiq tqdm for sequential computation

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -9,6 +9,7 @@ from joblib import effective_n_jobs
 from rdkit.Chem import Mol
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils._param_validation import InvalidParameterError
+from tqdm import tqdm
 
 from skfp.utils import ensure_mols, run_in_parallel
 
@@ -156,7 +157,12 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
 
         n_jobs = effective_n_jobs(self.n_jobs)
         if n_jobs == 1:
-            filter_indicators = self._filter_mols_batch(mols)
+            if self.verbose:
+                filter_indicators = [
+                    self._filter_mols_batch([mol]) for mol in tqdm(mols)
+                ]
+            else:
+                filter_indicators = self._filter_mols_batch(mols)
         else:
             filter_indicators = run_in_parallel(
                 self._filter_mols_batch,

--- a/skfp/bases/base_fp_transformer.py
+++ b/skfp/bases/base_fp_transformer.py
@@ -150,7 +150,7 @@ class BaseFingerprintTransformer(
 
         n_jobs = effective_n_jobs(self.n_jobs)
         if n_jobs == 1:
-            if self.verbose > 0:
+            if self.verbose:
                 results = [self._calculate_fingerprint([mol]) for mol in tqdm(X)]
             else:
                 results = self._calculate_fingerprint(X)

--- a/skfp/bases/base_fp_transformer.py
+++ b/skfp/bases/base_fp_transformer.py
@@ -22,6 +22,7 @@ from sklearn.base import (
     TransformerMixin,
 )
 from sklearn.utils._param_validation import InvalidParameterError
+from tqdm import tqdm
 
 from skfp.utils import run_in_parallel
 
@@ -149,7 +150,10 @@ class BaseFingerprintTransformer(
 
         n_jobs = effective_n_jobs(self.n_jobs)
         if n_jobs == 1:
-            results = self._calculate_fingerprint(X)
+            if self.verbose > 0:
+                results = [self._calculate_fingerprint([mol]) for mol in tqdm(X)]
+            else:
+                results = self._calculate_fingerprint(X)
         else:
             results = run_in_parallel(
                 self._calculate_fingerprint,

--- a/skfp/bases/base_preprocessor.py
+++ b/skfp/bases/base_preprocessor.py
@@ -6,6 +6,7 @@ from typing import Optional
 from joblib import effective_n_jobs
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils._param_validation import InvalidParameterError
+from tqdm import tqdm
 
 from skfp.utils import run_in_parallel
 
@@ -86,7 +87,10 @@ class BasePreprocessor(ABC, BaseEstimator, TransformerMixin):
 
         n_jobs = effective_n_jobs(self.n_jobs)
         if n_jobs == 1:
-            results = self._transform_batch(X)
+            if self.verbose:
+                results = [self._transform_batch([mol]) for mol in tqdm(X)]
+            else:
+                results = self._transform_batch(X)
         else:
             results = run_in_parallel(
                 self._transform_batch,


### PR DESCRIPTION
## Changes

We didn't honor the `verbose` option for sequential computation with tqdm, this PR fixes that behavior.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
