### PR TITLE
Pass Through Descriptor Names for Mordred / RDKit2DDescriptors

### DIFF
--- a/skfp/fingerprints/mordred_fp.py
+++ b/skfp/fingerprints/mordred_fp.py
@@ -123,7 +123,8 @@ class MordredFingerprint(BaseFingerprintTransformer):
         )
 
     def get_feature_names_out(self):
-        """Get output feature names for transformation.
+        """
+        Get fingerprint output feature names.
 
         Returns
         -------

--- a/skfp/fingerprints/mordred_fp.py
+++ b/skfp/fingerprints/mordred_fp.py
@@ -122,27 +122,14 @@ class MordredFingerprint(BaseFingerprintTransformer):
             else np.array(X, dtype=np.float32)
         )
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self):
         """Get output feature names for transformation.
-
-        Parameters
-        ----------
-        input_features : array-like of str or None, default=None
-            Input features.
-
-            - If `input_features` is `None`, then `feature_names_in_` is
-              used as feature names in. If `feature_names_in_` is not defined,
-              then the following input feature names are generated:
-              `["x0", "x1", ..., "x(n_features_in_ - 1)"]`.
-            - If `input_features` is an array-like, then `input_features` must
-              match `feature_names_in_` if `feature_names_in_` is defined.
 
         Returns
         -------
         feature_names_out : ndarray of str objects
-            Same as input features.
+            Names of the Mordred descriptors.
         """
-        super().get_feature_names_out(input_features)
         calc = Calculator(descriptors, ignore_3D=not self.use_3D)
 
         return np.asarray([str(d) for d in calc.descriptors], dtype=object)

--- a/skfp/fingerprints/mordred_fp.py
+++ b/skfp/fingerprints/mordred_fp.py
@@ -121,3 +121,9 @@ class MordredFingerprint(BaseFingerprintTransformer):
             if self.sparse
             else np.array(X, dtype=np.float32)
         )
+
+    def get_feature_names_out(self, input_features=None):
+        super().get_feature_names_out(input_features)
+        calc = Calculator(descriptors, ignore_3D=not self.use_3D)
+
+        return np.asarray([str(d) for d in calc.descriptors])

--- a/skfp/fingerprints/mordred_fp.py
+++ b/skfp/fingerprints/mordred_fp.py
@@ -123,6 +123,25 @@ class MordredFingerprint(BaseFingerprintTransformer):
         )
 
     def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input features.
+
+            - If `input_features` is `None`, then `feature_names_in_` is
+              used as feature names in. If `feature_names_in_` is not defined,
+              then the following input feature names are generated:
+              `["x0", "x1", ..., "x(n_features_in_ - 1)"]`.
+            - If `input_features` is an array-like, then `input_features` must
+              match `feature_names_in_` if `feature_names_in_` is defined.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Same as input features.
+        """
         super().get_feature_names_out(input_features)
         calc = Calculator(descriptors, ignore_3D=not self.use_3D)
 

--- a/skfp/fingerprints/mordred_fp.py
+++ b/skfp/fingerprints/mordred_fp.py
@@ -145,4 +145,4 @@ class MordredFingerprint(BaseFingerprintTransformer):
         super().get_feature_names_out(input_features)
         calc = Calculator(descriptors, ignore_3D=not self.use_3D)
 
-        return np.asarray([str(d) for d in calc.descriptors])
+        return np.asarray([str(d) for d in calc.descriptors], dtype=object)

--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -140,7 +140,8 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
             return np.array(X, dtype=np.float32)
 
     def get_feature_names_out(self):
-        """Get output feature names for transformation.
+        """
+        Get fingerprint output feature names.
 
         Returns
         -------

--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -138,3 +138,16 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
             return csr_array(X, dtype=np.float32)
         else:
             return np.array(X, dtype=np.float32)
+
+    def get_feature_names_out(self, input_features=None):
+        super().get_feature_names_out(input_features)
+
+        from descriptastorus.descriptors.rdDescriptors import RDKit2D
+        from descriptastorus.descriptors.rdNormalizedDescriptors import (
+            RDKit2DNormalized,
+        )
+
+        gen = RDKit2DNormalized() if self.normalized else RDKit2D()
+        names = list(zip(*gen.columns))[0]
+
+        return np.asarray(names)

--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -169,4 +169,4 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
         gen = RDKit2DNormalized() if self.normalized else RDKit2D()
         names = list(zip(*gen.columns))[0]
 
-        return np.asarray(names)
+        return np.asarray(names, dtype=object)

--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -140,6 +140,25 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
             return np.array(X, dtype=np.float32)
 
     def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input features.
+
+            - If `input_features` is `None`, then `feature_names_in_` is
+              used as feature names in. If `feature_names_in_` is not defined,
+              then the following input feature names are generated:
+              `["x0", "x1", ..., "x(n_features_in_ - 1)"]`.
+            - If `input_features` is an array-like, then `input_features` must
+              match `feature_names_in_` if `feature_names_in_` is defined.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Same as input features.
+        """
         super().get_feature_names_out(input_features)
 
         from descriptastorus.descriptors.rdDescriptors import RDKit2D

--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -139,28 +139,14 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
         else:
             return np.array(X, dtype=np.float32)
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self):
         """Get output feature names for transformation.
-
-        Parameters
-        ----------
-        input_features : array-like of str or None, default=None
-            Input features.
-
-            - If `input_features` is `None`, then `feature_names_in_` is
-              used as feature names in. If `feature_names_in_` is not defined,
-              then the following input feature names are generated:
-              `["x0", "x1", ..., "x(n_features_in_ - 1)"]`.
-            - If `input_features` is an array-like, then `input_features` must
-              match `feature_names_in_` if `feature_names_in_` is defined.
 
         Returns
         -------
         feature_names_out : ndarray of str objects
-            Same as input features.
+            Names of the RDKit 2D descriptors.
         """
-        super().get_feature_names_out(input_features)
-
         from descriptastorus.descriptors.rdDescriptors import RDKit2D
         from descriptastorus.descriptors.rdNormalizedDescriptors import (
             RDKit2DNormalized,

--- a/tests/fingerprints/mordred_fp.py
+++ b/tests/fingerprints/mordred_fp.py
@@ -12,10 +12,12 @@ def test_mordred_fingerprint(smallest_smiles_list, smallest_mols_list):
     calc = Calculator(descriptors, ignore_3D=True)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
+    colnames = mordred_transformer.get_feature_names_out()
 
     assert np.array_equal(X_skfp, X_seq, equal_nan=True)
     assert X_skfp.shape == (len(smallest_smiles_list), 1613)
     assert X_skfp.dtype == np.float32
+    assert np.array_equal(colnames, list(str(d) for d in calc.descriptors))
 
 
 def test_mordred_sparse_fingerprint(smallest_smiles_list, smallest_mols_list):
@@ -25,10 +27,12 @@ def test_mordred_sparse_fingerprint(smallest_smiles_list, smallest_mols_list):
     calc = Calculator(descriptors, ignore_3D=True)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
+    colnames = mordred_transformer.get_feature_names_out()
 
     assert np.array_equal(X_skfp.data, X_seq.data, equal_nan=True)
     assert X_skfp.shape == (len(smallest_smiles_list), 1613)
     assert X_skfp.dtype == np.float32
+    assert np.array_equal(colnames, list(str(d) for d in calc.descriptors))
 
 
 def test_mordred_3D_fingerprint(smallest_smiles_list, smallest_mols_list):
@@ -38,10 +42,12 @@ def test_mordred_3D_fingerprint(smallest_smiles_list, smallest_mols_list):
     calc = Calculator(descriptors, ignore_3D=False)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
+    colnames = mordred_transformer.get_feature_names_out()
 
     assert np.array_equal(X_skfp, X_seq, equal_nan=True)
     assert X_skfp.shape == (len(smallest_smiles_list), 1826)
     assert X_skfp.dtype == np.float32
+    assert np.array_equal(colnames, list(str(d) for d in calc.descriptors))
 
 
 def test_mordred_3D_sparse_fingerprint(smallest_smiles_list, smallest_mols_list):
@@ -51,7 +57,9 @@ def test_mordred_3D_sparse_fingerprint(smallest_smiles_list, smallest_mols_list)
     calc = Calculator(descriptors, ignore_3D=False)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
+    colnames = mordred_transformer.get_feature_names_out()
 
     assert np.array_equal(X_skfp.data, X_seq.data, equal_nan=True)
     assert X_skfp.shape == (len(smallest_smiles_list), 1826)
     assert X_skfp.dtype == np.float32
+    assert np.array_equal(colnames, list(str(d) for d in calc.descriptors))

--- a/tests/fingerprints/rdkit_2d_desc.py
+++ b/tests/fingerprints/rdkit_2d_desc.py
@@ -17,10 +17,12 @@ def test_rdkit_2d_desc_fingerprint(smallest_mols_list):
         ]
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.array(X_descriptastorus, dtype=np.float32)
+    colnames = getaway_fp.get_feature_names_out()
 
     assert np.allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
+    assert np.array_equal(colnames, list(zip(*gen.columns))[0])
 
 
 def test_rdkit_2d_desc_sparse_fingerprint(smallest_mols_list):
@@ -34,10 +36,12 @@ def test_rdkit_2d_desc_sparse_fingerprint(smallest_mols_list):
         ]
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
+    colnames = getaway_fp.get_feature_names_out()
 
     assert np.allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)  # type: ignore
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
+    assert np.array_equal(colnames, list(zip(*gen.columns))[0])
 
 
 def test_rdkit_2d_desc_normalized_fingerprint(smallest_mols_list):
@@ -51,10 +55,12 @@ def test_rdkit_2d_desc_normalized_fingerprint(smallest_mols_list):
         ]
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.row_stack(X_descriptastorus)
+    colnames = getaway_fp.get_feature_names_out()
 
     assert np.allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
+    assert np.array_equal(colnames, list(zip(*gen.columns))[0])
 
 
 def test_rdkit_2d_desc_normalized_sparse_fingerprint(smallest_mols_list):
@@ -68,7 +74,9 @@ def test_rdkit_2d_desc_normalized_sparse_fingerprint(smallest_mols_list):
         ]
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
+    colnames = getaway_fp.get_feature_names_out()
 
     assert np.allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)  # type: ignore
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
+    assert np.array_equal(colnames, list(zip(*gen.columns))[0])


### PR DESCRIPTION
## Changes

Progress for #310 
Pass through descriptor names from underlying mordred / rdkit2ddescriptor calculators via `get_feature_names_out`

## Notes
- [base class implementation](https://github.com/scikit-learn/scikit-learn/blob/a072e56fa/sklearn/base.py#L898) for reference
- [Mordred treatment of descriptor names](https://github.com/JacksonBurns/mordred-community/blob/23a3a3967968e9585b821de97ffca6095ff580d7/mordred/_base/calculator.py#L173)
- [RDKit treatment of descriptor names](https://github.com/bp-kelley/descriptastorus/blob/master/descriptastorus/descriptors/rdDescriptors.py#L439)
- Coverage: 
![image](https://github.com/user-attachments/assets/995ef100-122a-4599-bdf3-690b7e09ea1d)

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)