### PR TITLE
Small docs fix for splitters

### DIFF
--- a/skfp/model_selection/splitters/butina_split.py
+++ b/skfp/model_selection/splitters/butina_split.py
@@ -117,9 +117,9 @@ def butina_train_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-test subsets of provided arrays. First two are lists of SMILES
-    strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-test subsets of provided arrays. First two are lists of SMILES
+        strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
+        is True, lists of indices are returned instead of actual data.
 
     References
     ----------
@@ -303,9 +303,9 @@ def butina_train_valid_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-valid-test subsets of provided arrays. First three are lists of
-    SMILES strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-valid-test subsets of provided arrays. First three are lists of
+        SMILES strings or RDKit ``Mol`` objects, depending on the input type. If
+        `return_indices` is True, lists of indices are returned instead of actual data.
 
     References
     ----------

--- a/skfp/model_selection/splitters/maxmin_split.py
+++ b/skfp/model_selection/splitters/maxmin_split.py
@@ -89,9 +89,9 @@ def maxmin_train_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-test subsets of provided arrays. First two are lists of SMILES
-    strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-test subsets of provided arrays. First two are lists of SMILES
+        strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
+        is True, lists of indices are returned instead of actual data.
 
     References
     ----------
@@ -235,9 +235,9 @@ def maxmin_train_valid_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-valid-test subsets of provided arrays. First three are lists of
-    SMILES strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-valid-test subsets of provided arrays. First three are lists of
+        SMILES strings or RDKit ``Mol`` objects, depending on the input type. If
+        `return_indices` is True, lists of indices are returned instead of actual data.
 
     References
     ----------

--- a/skfp/model_selection/splitters/randomized_scaffold_split.py
+++ b/skfp/model_selection/splitters/randomized_scaffold_split.py
@@ -104,9 +104,9 @@ def randomized_scaffold_train_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-test subsets of provided arrays. First two are lists of SMILES
-    strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-test subsets of provided arrays. First two are lists of SMILES
+        strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
+        is True, lists of indices are returned instead of actual data.
 
     References
     ----------
@@ -269,9 +269,9 @@ def randomized_scaffold_train_valid_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-valid-test subsets of provided arrays. First three are lists of
-    SMILES strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-valid-test subsets of provided arrays. First three are lists of
+        SMILES strings or RDKit ``Mol`` objects, depending on the input type. If
+        `return_indices` is True, lists of indices are returned instead of actual data.
 
     References
     ----------

--- a/skfp/model_selection/splitters/scaffold_split.py
+++ b/skfp/model_selection/splitters/scaffold_split.py
@@ -101,9 +101,9 @@ def scaffold_train_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-test subsets of provided arrays. First two are lists of SMILES
-    strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-test subsets of provided arrays. First two are lists of SMILES
+        strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
+        is True, lists of indices are returned instead of actual data.
 
     References
     ----------
@@ -256,9 +256,9 @@ def scaffold_train_valid_test_split(
     Returns
     ----------
     subsets : tuple[list, list, ...]
-    Tuple with train-valid-test subsets of provided arrays. First three are lists of
-    SMILES strings or RDKit ``Mol`` objects, depending on the input type. If `return_indices`
-    is True, lists of indices are returned instead of actual data.
+        Tuple with train-valid-test subsets of provided arrays. First three are lists of
+        SMILES strings or RDKit ``Mol`` objects, depending on the input type. If
+        `return_indices` is True, lists of indices are returned instead of actual data.
 
     References
     ----------


### PR DESCRIPTION
## Changes

One tab was missing from docs.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
