### PR TITLE
Unify filter names

### DIFF
--- a/docs/modules/filters.rst
+++ b/docs/modules/filters.rst
@@ -32,11 +32,11 @@ Molecular filters
     PAINSFilter
     PfizerFilter
     REOSFilter
-    RuleOfFour
-    RuleOfThree
-    RuleOfTwo
-    RuleOfVeber
-    RuleOfXu
+    RuleOfFourFilter
+    RuleOfThreeFilter
+    RuleOfTwoFilter
+    RuleOfVeberFilter
+    RuleOfXuFilter
     SureChEMBLFilter
     TiceHerbicidesFilter
     TiceInsecticidesFilter

--- a/skfp/filters/__init__.py
+++ b/skfp/filters/__init__.py
@@ -18,11 +18,11 @@ from .oprea import OpreaFilter
 from .pains import PAINSFilter
 from .pfizer import PfizerFilter
 from .reos import REOSFilter
-from .rule_of_four import RuleOfFour
-from .rule_of_three import RuleOfThree
-from .rule_of_two import RuleOfTwo
-from .rule_of_veber import RuleOfVeber
-from .rule_of_xu import RuleOfXu
+from .rule_of_four import RuleOfFourFilter
+from .rule_of_three import RuleOfThreeFilter
+from .rule_of_two import RuleOfTwoFilter
+from .rule_of_veber import RuleOfVeberFilter
+from .rule_of_xu import RuleOfXuFilter
 from .surechembl import SureChEMBLFilter
 from .tice_herbicides import TiceHerbicidesFilter
 from .tice_insecticides import TiceInsecticidesFilter

--- a/skfp/filters/rule_of_four.py
+++ b/skfp/filters/rule_of_four.py
@@ -8,7 +8,7 @@ from rdkit.Chem.rdMolDescriptors import CalcNumHBA, CalcNumRings
 from skfp.bases.base_filter import BaseFilter
 
 
-class RuleOfFour(BaseFilter):
+class RuleOfFourFilter(BaseFilter):
     """
     Rule of four (Ro4).
 
@@ -54,10 +54,10 @@ class RuleOfFour(BaseFilter):
 
     Examples
     ---------
-    >>> from skfp.filters import RuleOfFour
+    >>> from skfp.filters import RuleOfFourFilter
     >>> smiles = ['c1ccc2oc(-c3ccc(Nc4nc(N5CCCCC5)nc(N5CCOCC5)n4)cc3)nc2c1', \
     'c1nc(N2CCOCC2)c2sc3nc(N4CCOCC4)c4c(c3c2n1)CCCC4']
-    >>> filt = RuleOfFour()
+    >>> filt = RuleOfFourFilter()
     >>> filt
     RuleOfFour()
     >>> filtered_mols = filt.transform(smiles)

--- a/skfp/filters/rule_of_four.py
+++ b/skfp/filters/rule_of_four.py
@@ -59,7 +59,7 @@ class RuleOfFourFilter(BaseFilter):
     'c1nc(N2CCOCC2)c2sc3nc(N4CCOCC4)c4c(c3c2n1)CCCC4']
     >>> filt = RuleOfFourFilter()
     >>> filt
-    RuleOfFour()
+    RuleOfFourFilter()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['c1ccc2oc(-c3ccc(Nc4nc(N5CCCCC5)nc(N5CCOCC5)n4)cc3)nc2c1']

--- a/skfp/filters/rule_of_three.py
+++ b/skfp/filters/rule_of_three.py
@@ -72,7 +72,7 @@ class RuleOfThreeFilter(BaseFilter):
     >>> smiles = ['C=CCNC(=S)NCc1ccccc1OC', 'C=CCOc1ccc(Br)cc1/C=N/O', 'C=CCNc1ncnc2ccccc12']
     >>> filt = RuleOfThreeFilter()
     >>> filt
-    RuleOfThree()
+    RuleOfThreeFilter()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['C=CCNC(=S)NCc1ccccc1OC', 'C=CCOc1ccc(Br)cc1/C=N/O', 'C=CCNc1ncnc2ccccc12']

--- a/skfp/filters/rule_of_three.py
+++ b/skfp/filters/rule_of_three.py
@@ -13,7 +13,7 @@ from rdkit.Chem.rdMolDescriptors import (
 from skfp.bases.base_filter import BaseFilter
 
 
-class RuleOfThree(BaseFilter):
+class RuleOfThreeFilter(BaseFilter):
     """
     Rule of three (Ro3).
 
@@ -68,15 +68,15 @@ class RuleOfThree(BaseFilter):
 
     Examples
     ----------
-    >>> from skfp.filters import RuleOfThree
+    >>> from skfp.filters import RuleOfThreeFilter
     >>> smiles = ['C=CCNC(=S)NCc1ccccc1OC', 'C=CCOc1ccc(Br)cc1/C=N/O', 'C=CCNc1ncnc2ccccc12']
-    >>> filt = RuleOfThree()
+    >>> filt = RuleOfThreeFilter()
     >>> filt
     RuleOfThree()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['C=CCNC(=S)NCc1ccccc1OC', 'C=CCOc1ccc(Br)cc1/C=N/O', 'C=CCNc1ncnc2ccccc12']
-    >>> filt = RuleOfThree(extended=True)
+    >>> filt = RuleOfThreeFilter(extended=True)
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['C=CCNc1ncnc2ccccc12']

--- a/skfp/filters/rule_of_two.py
+++ b/skfp/filters/rule_of_two.py
@@ -8,7 +8,7 @@ from rdkit.Chem.rdMolDescriptors import CalcNumHBA, CalcNumHBD
 from skfp.bases.base_filter import BaseFilter
 
 
-class RuleOfTwo(BaseFilter):
+class RuleOfTwoFilter(BaseFilter):
     """
     Rule of two (Ro2).
 
@@ -53,9 +53,9 @@ class RuleOfTwo(BaseFilter):
 
     Examples
     ----------
-    >>> from skfp.filters import RuleOfTwo
+    >>> from skfp.filters import RuleOfTwoFilter
     >>> smiles = ['C=CCc1c(C)[nH]c(N)nc1=O', 'C=CCNC(=O)c1ccncc1', 'C=CCC1C=C(C)CC(CC=C)N1']
-    >>> filt = RuleOfTwo()
+    >>> filt = RuleOfTwoFilter()
     >>> filt
     RuleOfTwo()
     >>> filtered_mols = filt.transform(smiles)

--- a/skfp/filters/rule_of_two.py
+++ b/skfp/filters/rule_of_two.py
@@ -57,7 +57,7 @@ class RuleOfTwoFilter(BaseFilter):
     >>> smiles = ['C=CCc1c(C)[nH]c(N)nc1=O', 'C=CCNC(=O)c1ccncc1', 'C=CCC1C=C(C)CC(CC=C)N1']
     >>> filt = RuleOfTwoFilter()
     >>> filt
-    RuleOfTwo()
+    RuleOfTwoFilter()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['C=CCc1c(C)[nH]c(N)nc1=O', 'C=CCNC(=O)c1ccncc1']

--- a/skfp/filters/rule_of_veber.py
+++ b/skfp/filters/rule_of_veber.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Mol, rdMolDescriptors
 from skfp.bases.base_filter import BaseFilter
 
 
-class RuleOfVeber(BaseFilter):
+class RuleOfVeberFilter(BaseFilter):
     """
     Rule of Veber.
 
@@ -50,9 +50,9 @@ class RuleOfVeber(BaseFilter):
 
     Examples
     ----------
-    >>> from skfp.filters import RuleOfVeber
+    >>> from skfp.filters import RuleOfVeberFilter
     >>> smiles = ["CC=O", "CC(C)[C@@H](CC1=CC(=C(C=C1)OC)OCCCOC)C[C@@H]([C@H](C[C@@H](C(C)C)C(=O)NCC(C)(C)C(=O)N)O)N"]
-    >>> filt = RuleOfVeber()
+    >>> filt = RuleOfVeberFilter()
     >>> filt
     RuleOfVeber()
     >>> filtered_mols = filt.transform(smiles)

--- a/skfp/filters/rule_of_veber.py
+++ b/skfp/filters/rule_of_veber.py
@@ -54,7 +54,7 @@ class RuleOfVeberFilter(BaseFilter):
     >>> smiles = ["CC=O", "CC(C)[C@@H](CC1=CC(=C(C=C1)OC)OCCCOC)C[C@@H]([C@H](C[C@@H](C(C)C)C(=O)NCC(C)(C)C(=O)N)O)N"]
     >>> filt = RuleOfVeberFilter()
     >>> filt
-    RuleOfVeber()
+    RuleOfVeberFilter()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['CC=O']

--- a/skfp/filters/rule_of_xu.py
+++ b/skfp/filters/rule_of_xu.py
@@ -55,7 +55,7 @@ class RuleOfXuFilter(BaseFilter):
     >>> smiles = ["CCO", "CC(=O)CC(C1=CC=CC=C1)C2=C(C3=CC=CC=C3OC2=O)O"]
     >>> filt = RuleOfXuFilter()
     >>> filt
-    RuleOfXu()
+    RuleOfXuFilter()
     >>> filtered_mols = filt.transform(smiles)
     >>> filtered_mols
     ['CC(=O)CC(C1=CC=CC=C1)C2=C(C3=CC=CC=C3OC2=O)O']

--- a/skfp/filters/rule_of_xu.py
+++ b/skfp/filters/rule_of_xu.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Mol, rdMolDescriptors
 from skfp.bases.base_filter import BaseFilter
 
 
-class RuleOfXu(BaseFilter):
+class RuleOfXuFilter(BaseFilter):
     """
     Rule of Xu.
 
@@ -51,9 +51,9 @@ class RuleOfXu(BaseFilter):
 
     Examples
     ----------
-    >>> from skfp.filters import RuleOfXu
+    >>> from skfp.filters import RuleOfXuFilter
     >>> smiles = ["CCO", "CC(=O)CC(C1=CC=CC=C1)C2=C(C3=CC=CC=C3OC2=O)O"]
-    >>> filt = RuleOfXu()
+    >>> filt = RuleOfXuFilter()
     >>> filt
     RuleOfXu()
     >>> filtered_mols = filt.transform(smiles)

--- a/tests/filters/rule_of_four.py
+++ b/tests/filters/rule_of_four.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from skfp.filters import RuleOfFour
+from skfp.filters import RuleOfFourFilter
 
 
 @pytest.fixture
@@ -34,14 +34,14 @@ def smiles_passing_one_violation_rule_of_four() -> list[str]:
 def test_mols_passing_rule_of_four(
     smiles_passing_rule_of_four,
 ):
-    mol_filter = RuleOfFour()
+    mol_filter = RuleOfFourFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_four)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_rule_of_four)
 
 
 def test_mols_failing_rule_of_four(smiles_failing_rule_of_four):
-    mol_filter = RuleOfFour()
+    mol_filter = RuleOfFourFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_four)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == 0
@@ -50,11 +50,11 @@ def test_mols_failing_rule_of_four(smiles_failing_rule_of_four):
 def test_mols_passing_with_violation_rule_of_four(
     smiles_passing_one_violation_rule_of_four,
 ):
-    mol_filter = RuleOfFour(allow_one_violation=True)
+    mol_filter = RuleOfFourFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_four)
     assert len(smiles_filtered) == 3
 
-    mol_filter = RuleOfFour(allow_one_violation=False)
+    mol_filter = RuleOfFourFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_four)
     assert len(smiles_filtered) == 0
 
@@ -70,7 +70,7 @@ def test_rule_of_four_return_indicators(
         + smiles_passing_one_violation_rule_of_four
     )
 
-    mol_filter = RuleOfFour(return_indicators=True)
+    mol_filter = RuleOfFourFilter(return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_four)
@@ -80,7 +80,7 @@ def test_rule_of_four_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfFour(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfFourFilter(allow_one_violation=True, return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_four)
@@ -92,10 +92,10 @@ def test_rule_of_four_return_indicators(
 
 
 def test_rule_of_four_parallel(smiles_list):
-    mol_filter = RuleOfFour()
+    mol_filter = RuleOfFourFilter()
     mols_filtered_sequential = mol_filter.transform(smiles_list)
 
-    mol_filter = RuleOfFour(n_jobs=-1, batch_size=1)
+    mol_filter = RuleOfFourFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
     assert mols_filtered_sequential == mols_filtered_parallel

--- a/tests/filters/rule_of_three.py
+++ b/tests/filters/rule_of_three.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from skfp.filters import RuleOfThree
+from skfp.filters import RuleOfThreeFilter
 
 
 @pytest.fixture
@@ -51,28 +51,28 @@ def smiles_passing_one_violation_extended_rule_of_three() -> list[str]:
 
 
 def test_mols_passing_basic_rule_of_three(smiles_passing_basic_rule_of_three):
-    mol_filter = RuleOfThree()
+    mol_filter = RuleOfThreeFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_basic_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_basic_rule_of_three)
 
 
 def test_mols_passing_extended_rule_of_three(smiles_passing_extended_rule_of_three):
-    mol_filter = RuleOfThree(extended=True)
+    mol_filter = RuleOfThreeFilter(extended=True)
     smiles_filtered = mol_filter.transform(smiles_passing_extended_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_extended_rule_of_three)
 
 
 def test_mols_failing_basic_rule_of_three(smiles_failing_basic_rule_of_three):
-    mol_filter = RuleOfThree()
+    mol_filter = RuleOfThreeFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_basic_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_failing_basic_rule_of_three)
     assert len(smiles_filtered) == 0
 
 
 def test_mols_failing_extended_rule_of_three(smiles_failing_extended_rule_of_three):
-    mol_filter = RuleOfThree(extended=True)
+    mol_filter = RuleOfThreeFilter(extended=True)
     smiles_filtered = mol_filter.transform(smiles_failing_extended_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == 0
@@ -81,13 +81,13 @@ def test_mols_failing_extended_rule_of_three(smiles_failing_extended_rule_of_thr
 def test_mols_passing_with_violation_basic_rule_of_three(
     smiles_passing_one_violation_basic_rule_of_three,
 ):
-    mol_filter = RuleOfThree(allow_one_violation=True)
+    mol_filter = RuleOfThreeFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_basic_rule_of_three
     )
     assert len(smiles_filtered) == 3
 
-    mol_filter = RuleOfThree(allow_one_violation=False)
+    mol_filter = RuleOfThreeFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_basic_rule_of_three
     )
@@ -97,13 +97,13 @@ def test_mols_passing_with_violation_basic_rule_of_three(
 def test_mols_passing_with_violation_extended_rule_of_three(
     smiles_passing_one_violation_extended_rule_of_three,
 ):
-    mol_filter = RuleOfThree(allow_one_violation=True, extended=True)
+    mol_filter = RuleOfThreeFilter(allow_one_violation=True, extended=True)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_extended_rule_of_three
     )
     assert len(smiles_filtered) == 3
 
-    mol_filter = RuleOfThree(allow_one_violation=False, extended=True)
+    mol_filter = RuleOfThreeFilter(allow_one_violation=False, extended=True)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_extended_rule_of_three
     )
@@ -121,7 +121,7 @@ def test_rule_of_three_return_indicators(
         + smiles_passing_one_violation_extended_rule_of_three
     )
 
-    mol_filter = RuleOfThree(extended=True, return_indicators=True)
+    mol_filter = RuleOfThreeFilter(extended=True, return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_extended_rule_of_three)
@@ -131,7 +131,7 @@ def test_rule_of_three_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfThree(
+    mol_filter = RuleOfThreeFilter(
         extended=True, allow_one_violation=True, return_indicators=True
     )
     filter_indicators = mol_filter.transform(all_smiles)
@@ -145,10 +145,10 @@ def test_rule_of_three_return_indicators(
 
 
 def test_rule_of_three_parallel(smiles_list):
-    mol_filter = RuleOfThree(extended=True)
+    mol_filter = RuleOfThreeFilter(extended=True)
     mols_filtered_sequential = mol_filter.transform(smiles_list)
 
-    mol_filter = RuleOfThree(extended=True, n_jobs=-1, batch_size=1)
+    mol_filter = RuleOfThreeFilter(extended=True, n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
     assert mols_filtered_sequential == mols_filtered_parallel

--- a/tests/filters/rule_of_two.py
+++ b/tests/filters/rule_of_two.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from skfp.filters import RuleOfTwo
+from skfp.filters import RuleOfTwoFilter
 
 
 @pytest.fixture
@@ -24,14 +24,14 @@ def smiles_passing_one_violation_rule_of_two() -> list[str]:
 
 
 def test_mols_passing_rule_of_two(smiles_passing_rule_of_two):
-    mol_filter = RuleOfTwo()
+    mol_filter = RuleOfTwoFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_two)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_rule_of_two)
 
 
 def test_mols_failing_rule_of_two(smiles_failing_rule_of_two):
-    mol_filter = RuleOfTwo()
+    mol_filter = RuleOfTwoFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_two)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == 0
@@ -40,11 +40,11 @@ def test_mols_failing_rule_of_two(smiles_failing_rule_of_two):
 def test_mols_passing_with_violation_rule_of_two(
     smiles_passing_one_violation_rule_of_two,
 ):
-    mol_filter = RuleOfTwo(allow_one_violation=True)
+    mol_filter = RuleOfTwoFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_two)
     assert len(smiles_filtered) == 3
 
-    mol_filter = RuleOfTwo(allow_one_violation=False)
+    mol_filter = RuleOfTwoFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_two)
     assert len(smiles_filtered) == 0
 
@@ -60,7 +60,7 @@ def test_rule_of_two_return_indicators(
         + smiles_passing_one_violation_rule_of_two
     )
 
-    mol_filter = RuleOfTwo(return_indicators=True)
+    mol_filter = RuleOfTwoFilter(return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_two)
@@ -70,7 +70,7 @@ def test_rule_of_two_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfTwo(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfTwoFilter(allow_one_violation=True, return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_two)
@@ -82,10 +82,10 @@ def test_rule_of_two_return_indicators(
 
 
 def test_rule_of_two_parallel(smiles_list):
-    mol_filter = RuleOfTwo()
+    mol_filter = RuleOfTwoFilter()
     mols_filtered_sequential = mol_filter.transform(smiles_list)
 
-    mol_filter = RuleOfTwo(n_jobs=-1, batch_size=1)
+    mol_filter = RuleOfTwoFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
     assert mols_filtered_sequential == mols_filtered_parallel

--- a/tests/filters/rule_of_veber.py
+++ b/tests/filters/rule_of_veber.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from skfp.filters import RuleOfVeber
+from skfp.filters import RuleOfVeberFilter
 
 
 @pytest.fixture
@@ -26,21 +26,21 @@ def smiles_failing_rule_of_veber() -> list[str]:
 
 
 def test_mols_passing_rule_of_veber(smiles_passing_rule_of_veber):
-    mol_filter = RuleOfVeber()
+    mol_filter = RuleOfVeberFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_veber)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_rule_of_veber)
 
 
 def test_mols_partially_passing_rule_of_veber(smiles_passing_one_fail):
-    mol_filter = RuleOfVeber(allow_one_violation=True)
+    mol_filter = RuleOfVeberFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_one_fail)
 
 
 def test_mols_failing_rule_of_veber(smiles_failing_rule_of_veber):
-    mol_filter = RuleOfVeber()
+    mol_filter = RuleOfVeberFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_veber)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == 0
@@ -57,7 +57,7 @@ def test_rule_of_veber_return_indicators(
         + smiles_passing_one_fail
     )
 
-    mol_filter = RuleOfVeber(return_indicators=True)
+    mol_filter = RuleOfVeberFilter(return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_veber)
@@ -67,7 +67,7 @@ def test_rule_of_veber_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfVeber(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfVeberFilter(allow_one_violation=True, return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_veber)
@@ -79,10 +79,10 @@ def test_rule_of_veber_return_indicators(
 
 
 def test_rule_of_veber_parallel(smiles_list):
-    mol_filter = RuleOfVeber()
+    mol_filter = RuleOfVeberFilter()
     mols_filtered_sequential = mol_filter.transform(smiles_list)
 
-    mol_filter = RuleOfVeber(n_jobs=-1, batch_size=1)
+    mol_filter = RuleOfVeberFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
     assert mols_filtered_sequential == mols_filtered_parallel

--- a/tests/filters/rule_of_xu.py
+++ b/tests/filters/rule_of_xu.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from skfp.filters import RuleOfXu
+from skfp.filters import RuleOfXuFilter
 
 
 @pytest.fixture
@@ -31,21 +31,21 @@ def smiles_failing_rule_of_xu() -> list[str]:
 
 
 def test_mols_passing_rule_of_xu(smiles_passing_rule_of_xu):
-    mol_filter = RuleOfXu()
+    mol_filter = RuleOfXuFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_xu)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_rule_of_xu)
 
 
 def test_mols_partially_passing_rule_of_xu(smiles_passing_one_fail):
-    mol_filter = RuleOfXu(allow_one_violation=True)
+    mol_filter = RuleOfXuFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_one_fail)
 
 
 def test_mols_failing_rule_of_xu(smiles_failing_rule_of_xu):
-    mol_filter = RuleOfXu()
+    mol_filter = RuleOfXuFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_xu)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == 0
@@ -60,7 +60,7 @@ def test_rule_of_xu_return_indicators(
         smiles_passing_rule_of_xu + smiles_failing_rule_of_xu + smiles_passing_one_fail
     )
 
-    mol_filter = RuleOfXu(return_indicators=True)
+    mol_filter = RuleOfXuFilter(return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_xu)
@@ -70,7 +70,7 @@ def test_rule_of_xu_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfXu(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfXuFilter(allow_one_violation=True, return_indicators=True)
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_xu)
@@ -82,10 +82,10 @@ def test_rule_of_xu_return_indicators(
 
 
 def test_rule_of_xu_parallel(smiles_list):
-    mol_filter = RuleOfXu()
+    mol_filter = RuleOfXuFilter()
     mols_filtered_sequential = mol_filter.transform(smiles_list)
 
-    mol_filter = RuleOfXu(n_jobs=-1, batch_size=1)
+    mol_filter = RuleOfXuFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
     assert mols_filtered_sequential == mols_filtered_parallel


### PR DESCRIPTION
## Changes

Makes sure that all filters end with `Filter`.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
