### PR TITLE
Expand run_in_parallel for non-batch functions

### DIFF
--- a/tests/utils/parallel.py
+++ b/tests/utils/parallel.py
@@ -53,3 +53,11 @@ def test_run_in_parallel_invalid_batch_size():
         run_in_parallel(func, data, n_jobs=-1, batch_size=-1, flatten_results=True)
 
     assert "batch_size must be positive" in str(exc_info)
+
+
+def test_run_in_parallel_single_element_func():
+    func = lambda x: x + 1
+    data = list(range(100))
+    result_parallel = run_in_parallel(func, data, n_jobs=-1, single_element_func=True)
+    expected_result = list(range(1, 101))
+    assert result_parallel == expected_result


### PR DESCRIPTION
## Changes

`run_in_parallel` currently supports only functions operating on batches of data. I expanded this to also work on a single element functions.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
