### PR TITLE
Add MAP chirality

### DIFF
--- a/skfp/fingerprints/lingo.py
+++ b/skfp/fingerprints/lingo.py
@@ -85,7 +85,6 @@ class LingoFingerprint(BaseFingerprintTransformer):
         **BaseFingerprintTransformer._parameter_constraints,
         "fp_size": [Interval(Integral, 1, None, closed="left")],
         "substring_length": [Interval(Integral, 1, None, closed="left")],
-        "count": ["boolean"],
     }
 
     def __init__(

--- a/tests/fingerprints/map.py
+++ b/tests/fingerprints/map.py
@@ -126,3 +126,9 @@ def test_map_sparse_raw_hashes_fingerprint(smallest_smiles_list, smallest_mols_l
     assert np.array_equal(X_skfp.data, X_map.data)
     assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
     assert np.issubdtype(X_skfp.dtype, np.integer)
+
+
+def test_map_chirality(smallest_mols_list):
+    # smoke test, this should not throw an error
+    map_fp = MAPFingerprint(include_chirality=True, n_jobs=-1)
+    map_fp.transform(smallest_mols_list)


### PR DESCRIPTION
## Changes

Implements MAPC fingerprint, i.e. adds chirality to MAP fingerprint.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
