### PR TITLE
Filters fixes and refactor dataset tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ doctest: docs ## Run documentation tests
 
 test: ## Run tests
 	poetry run ruff check
-	# reruns due to HuggingFace API rate limiting
-	poetry run pytest --reruns 20 --reruns-delay 5 --only-rerun LocalEntryNotFoundError --only-rerun FileNotFoundError tests
+	poetry run pytest tests
 
 test-coverage: ## Run tests and calculate test coverage
 	-mkdir .tmp_coverage_files

--- a/skfp/filters/bms.py
+++ b/skfp/filters/bms.py
@@ -11,7 +11,7 @@ class BMSFilter(BaseFilter):
     BMS filter.
 
     Designed at BMS (Bristol-Myers Squibb) for filtering HTS decks in primary screening.
-    Aims to remove molecules containing certin functional groups to filter out random
+    Aims to remove molecules containing certain functional groups to filter out random
     noise, “promiscuous” compounds, and frequent hitters.
 
     Selected functional groups for filtering are divided in the paper into "exclusion
@@ -19,7 +19,7 @@ class BMSFilter(BaseFilter):
     from the paper, so this is a best-effort approximation from RDKit.
 
     Rule definitions are available in the supplementary material of the original
-    publication [1]_ and in RDKit code [2]_. Note that
+    publication [1]_ and in RDKit code [2]_.
 
     Parameters
     ----------

--- a/skfp/filters/faf4_druglike.py
+++ b/skfp/filters/faf4_druglike.py
@@ -55,7 +55,7 @@ class FAF4DruglikeFilter(BaseFilter):
 
     Note that the FAFDrugs4 uses ChemAxon for determining functional groups. We use
     their publicly available CXSMARTS list of functional groups [3]_. Phosphine and
-    sulfoxide patterns could not be parsed by RDKit, so we manually fixed them.
+    sulfoxide patterns could not be parsed by RDKit, so they were fixed appropriately.
 
     Parameters
     ----------

--- a/skfp/filters/faf4_leadlike.py
+++ b/skfp/filters/faf4_leadlike.py
@@ -31,8 +31,8 @@ class FAF4LeadlikeFilter(BaseFilter):
     Designed as a part of FAFDrugs4 software [1]_ [2]_. Based on literature describing
     physico-chemical properties of lead drugs. Designed to keep starting point molecules
     that can be further optimized, i.e. relatively small, with low logP, and that can
-    be "decorated" further to increase affinity and or selectivity without becoming
-    very ADMET unfriendly).
+    be "decorated" further to increase affinity and/or selectivity, without becoming
+    very ADMET unfriendly.
 
     Basically a more restrictive variant of FAFDrugs4 Drug-Like Soft filter.
 
@@ -56,7 +56,7 @@ class FAF4LeadlikeFilter(BaseFilter):
 
     Note that the FAF4Drugs uses ChemAxon for determining functional groups. We use
     their publicly available CXSMARTS list of functional groups [3]_. Phosphine and
-    sulfoxide patterns could not be parsed by RDKit, so we manually fixed them.
+    sulfoxide patterns could not be parsed by RDKit, so they were fixed appropriately.
 
     Parameters
     ----------

--- a/skfp/filters/glaxo.py
+++ b/skfp/filters/glaxo.py
@@ -13,7 +13,7 @@ class GlaxoFilter(BaseFilter):
     Designed at Glaxo Wellcome (currently GSK) to filter out molecules with reactive
     functional groups, unsuitable leads (i.e. compounds which would not be initially
     followed up), and unsuitable natural products (i.e., derivatives of natural product
-    compounds known to interfere with to interfere with common assay procedures).
+    compounds known to interfere with common assay procedures).
 
     Rule definitions are available in the supplementary material of the original
     publication [1]_ and in RDKit code [2]_.

--- a/skfp/filters/nibr.py
+++ b/skfp/filters/nibr.py
@@ -20,6 +20,9 @@ class NIBRFilter(BaseFilter):
     rules are not used. Note that some rules may need to be fulfilled many times to
     fulfill the condition.
 
+    Note that this filter can be considerably slower than others due to a large
+    number of rules checked with SMARTS patterns.
+
     Parameter
     ----------
     allow_one_violation : bool, default=False

--- a/skfp/utils/validators.py
+++ b/skfp/utils/validators.py
@@ -16,8 +16,7 @@ def ensure_mols(X: Sequence[Any]) -> list[Mol]:
     if not all(isinstance(x, (Mol, PropertyMol, str)) for x in X):
         types = {type(x) for x in X}
         raise ValueError(
-            f"Passed values must be RDKit Mol objects or SMILES strings,"
-            f"got types: {types}"
+            f"Passed values must be RDKit Mol objects or SMILES strings, got types: {types}"
         )
 
     mols = [MolFromSmiles(x) if isinstance(x, str) else x for x in X]
@@ -83,7 +82,8 @@ def require_strings(X: Sequence[Any]) -> None:
 def require_atoms(min_atoms: int = 1) -> Callable:
     """
     Decorator for functions operating on single molecule. Ensures it is
-    nonempty (by default) or has at least the specified number of atoms, raises ValueError otherwise.
+    nonempty (by default) or has at least the specified number of atoms,
+    raises ValueError otherwise.
     """  # noqa: D401
 
     def decorator(func: Callable) -> Callable:
@@ -91,7 +91,8 @@ def require_atoms(min_atoms: int = 1) -> Callable:
         def wrapper(mol: Mol, *args, **kwargs):
             if mol.GetNumAtoms() < min_atoms:
                 raise ValueError(
-                    f"The molecule must have at least {min_atoms} atom(s), {func.__name__} cannot be calculated."
+                    f"The molecule must have at least {min_atoms} atom(s), "
+                    f"{func.__name__} cannot be calculated."
                 )
             return func(mol, *args, **kwargs)
 

--- a/tests/datasets/lrgb.py
+++ b/tests/datasets/lrgb.py
@@ -14,6 +14,11 @@ def get_dataset_names() -> list[str]:
     return ["Peptides-func", "Peptides-struct"]
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_lrgb_benchmark():
     dataset_names = get_dataset_names()
     benchmark_full = load_lrgb_mol_benchmark(as_frames=True)
@@ -21,6 +26,11 @@ def test_load_lrgb_benchmark():
     assert benchmark_names == dataset_names
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", get_dataset_names())
 def test_load_lrgb_splits(dataset_name):
     train, valid, test = load_lrgb_mol_splits(dataset_name)
@@ -40,6 +50,11 @@ def test_load_lrgb_splits(dataset_name):
     assert len(train) > len(test)
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", get_dataset_names())
 def test_load_lrgb_splits_as_dict(dataset_name):
     train, valid, test = load_lrgb_mol_splits(dataset_name)
@@ -51,6 +66,11 @@ def test_load_lrgb_splits_as_dict(dataset_name):
     assert split_idxs["test"] == test
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
     [
@@ -64,6 +84,11 @@ def test_load_lrgb_splits_lengths(dataset_name, dataset_length):
     assert loaded_length == dataset_length
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
     [

--- a/tests/datasets/moleculenet.py
+++ b/tests/datasets/moleculenet.py
@@ -22,12 +22,22 @@ from skfp.datasets.moleculenet.benchmark import MOLECULENET_DATASET_NAMES
 from tests.datasets.test_utils import run_basic_dataset_checks
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_moleculenet_benchmark():
     benchmark_full = load_moleculenet_benchmark(as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
     assert benchmark_names == MOLECULENET_DATASET_NAMES
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_moleculenet_benchmark_subset():
     dataset_names = ["ESOL", "SIDER", "BACE"]
     benchmark_full = load_moleculenet_benchmark(subset=dataset_names, as_frames=True)
@@ -35,6 +45,11 @@ def test_load_moleculenet_benchmark_subset():
     assert benchmark_names == dataset_names
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_moleculenet_benchmark_wrong_subset():
     dataset_names = ["ESOL", "Nonexistent"]
     with pytest.raises(ValueError) as exc_info:
@@ -43,6 +58,11 @@ def test_load_moleculenet_benchmark_wrong_subset():
     assert "Dataset name 'Nonexistent' not recognized" in str(exc_info)
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", MOLECULENET_DATASET_NAMES)
 def test_load_ogb_splits(dataset_name):
     train, valid, test = load_ogb_splits(dataset_name)
@@ -62,6 +82,11 @@ def test_load_ogb_splits(dataset_name):
     assert len(train) > len(test)
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", MOLECULENET_DATASET_NAMES)
 def test_load_ogb_splits_as_dict(dataset_name):
     train, valid, test = load_ogb_splits(dataset_name)
@@ -73,6 +98,11 @@ def test_load_ogb_splits_as_dict(dataset_name):
     assert split_idxs["test"] == test
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
     [
@@ -96,6 +126,11 @@ def test_load_ogb_splits_lengths(dataset_name, dataset_length):
     assert loaded_length == dataset_length
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_ogb_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
         load_ogb_splits("nonexistent")
@@ -105,6 +140,11 @@ def test_load_ogb_splits_nonexistent_dataset():
     )
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
     [

--- a/tests/datasets/tdc.py
+++ b/tests/datasets/tdc.py
@@ -48,12 +48,22 @@ from skfp.datasets.tdc.tox import (
 from tests.datasets.test_utils import run_basic_dataset_checks
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_tdc_benchmark():
     benchmark_full = load_tdc_benchmark(as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
     assert benchmark_names == TDC_DATASET_NAMES
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_tdc_benchmark_subset():
     dataset_names = ["pampa_approved_drugs", "sarscov2_3clpro_diamond", "ames"]
     benchmark_full = load_tdc_benchmark(subset=dataset_names, as_frames=True)
@@ -61,6 +71,11 @@ def test_load_tdc_benchmark_subset():
     assert benchmark_names == dataset_names
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_tdc_benchmark_wrong_subset():
     dataset_names = ["pampa_approved_drugs", "Nonexistent"]
     with pytest.raises(ValueError) as exc_info:
@@ -69,6 +84,11 @@ def test_load_tdc_benchmark_wrong_subset():
     assert "Dataset name 'Nonexistent' not recognized" in str(exc_info)
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", TDC_DATASET_NAMES)
 def test_load_tdc_splits(dataset_name):
     train, valid, test = load_tdc_splits(dataset_name)
@@ -88,6 +108,11 @@ def test_load_tdc_splits(dataset_name):
     assert len(train) > len(test)
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize("dataset_name", TDC_DATASET_NAMES)
 def test_load_ogb_splits_as_dict(dataset_name):
     train, valid, test = load_tdc_splits(dataset_name)
@@ -99,6 +124,11 @@ def test_load_ogb_splits_as_dict(dataset_name):
     assert split_idxs["test"] == test
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
     [
@@ -146,6 +176,11 @@ def test_load_tdc_splits_lengths(dataset_name, dataset_length):
     assert loaded_length == dataset_length
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 def test_load_tdc_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
         load_tdc_splits("nonexistent")
@@ -157,6 +192,11 @@ def test_load_tdc_splits_nonexistent_dataset():
     )
 
 
+@pytest.mark.flaky(
+    reruns=100,
+    reruns_delay=5,
+    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+)
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
     [


### PR DESCRIPTION
## Changes

Refactored dataset tests to use flaky tests instead of retries in Makefile, and also fixed a few typos in filters.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
