### PR TITLE
Add stratified MaxMin split

### DIFF
--- a/docs/modules/model_selection.rst
+++ b/docs/modules/model_selection.rst
@@ -29,6 +29,8 @@ Splitters:
     butina_train_valid_test_split
     maxmin_train_test_split
     maxmin_train_valid_test_split
+    maxmin_stratified_train_test_split
+    maxmin_stratified_train_valid_test_split
     randomized_scaffold_train_test_split
     randomized_scaffold_train_valid_test_split
     scaffold_train_test_split

--- a/skfp/model_selection/__init__.py
+++ b/skfp/model_selection/__init__.py
@@ -5,6 +5,8 @@ from .hyperparam_search import (
 from .splitters import (
     butina_train_test_split,
     butina_train_valid_test_split,
+    maxmin_stratified_train_test_split,
+    maxmin_stratified_train_valid_test_split,
     maxmin_train_test_split,
     maxmin_train_valid_test_split,
     randomized_scaffold_train_test_split,

--- a/skfp/model_selection/splitters/__init__.py
+++ b/skfp/model_selection/splitters/__init__.py
@@ -1,5 +1,10 @@
 from .butina_split import butina_train_test_split, butina_train_valid_test_split
-from .maxmin_split import maxmin_train_test_split, maxmin_train_valid_test_split
+from .maxmin_split import (
+    maxmin_stratified_train_test_split,
+    maxmin_stratified_train_valid_test_split,
+    maxmin_train_test_split,
+    maxmin_train_valid_test_split,
+)
 from .pubchem_split import pubchem_train_test_split, pubchem_train_valid_test_split
 from .randomized_scaffold_split import (
     randomized_scaffold_train_test_split,

--- a/skfp/model_selection/splitters/maxmin_split.py
+++ b/skfp/model_selection/splitters/maxmin_split.py
@@ -351,8 +351,9 @@ def maxmin_stratified_train_test_split(
     Split using MaxMin algorithm with stratification.
 
     A variant of MaxMin split (see :py:func:`maxmin_train_test_split`), modified to
-    split each class separately. This preserves the relative class proportions in the
-    resulting train and test splits.
+    split each class separately. The goal is to preserve the class distribution in
+    the resulting train and test splits, while also distributing points in each subset
+    across the chemical space.
 
     Note that results may differ quite strongly from regular MaxMin split, as here
     classes are treated independently of each other. While the distances between
@@ -496,9 +497,10 @@ def maxmin_stratified_train_valid_test_split(
     """
     Split using MaxMin algorithm with stratification.
 
-    A variant of MaxMin split (see :py:func:`maxmin_train_valid_test_split`), modified to
-    split each class separately. This preserves the relative class proportions in the
-    resulting train, valid, and test splits.
+    A variant of MaxMin split (see :py:func:`maxmin_train_valid_test_split`), modified
+    to split each class separately. The goal is to preserve the class distribution in
+    the resulting train, valid, and test splits, while also distributing points in each
+    subset across the chemical space.
 
     Note that results may differ quite strongly from regular MaxMin split, as here
     classes are treated independently of each other. While the distances between

--- a/skfp/model_selection/splitters/maxmin_split.py
+++ b/skfp/model_selection/splitters/maxmin_split.py
@@ -2,6 +2,8 @@ from collections.abc import Sequence
 from numbers import Integral
 from typing import Any
 
+import numpy as np
+import pandas as pd
 from rdkit.Chem import Mol
 from rdkit.Chem.rdFingerprintGenerator import GetMorganGenerator
 from rdkit.SimDivFilters.rdSimDivPickers import MaxMinPicker
@@ -311,3 +313,316 @@ def maxmin_train_valid_test_split(
         return train_subset, valid_subset, test_subset, *additional_data_split
     else:
         return train_subset, valid_subset, test_subset
+
+
+@validate_params(
+    {
+        "data": ["array-like"],
+        "labels": ["array-like"],
+        "additional_data": ["tuple"],
+        "train_size": [
+            Interval(RealNotInt, 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
+            None,
+        ],
+        "test_size": [
+            Interval(RealNotInt, 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
+            None,
+        ],
+        "return_indices": ["boolean"],
+    },
+    prefer_skip_nested_validation=True,
+)
+def maxmin_stratified_train_test_split(
+    data: Sequence[str | Mol],
+    labels: np.ndarray | list[int] | pd.Series,
+    *additional_data: Sequence,
+    train_size: float | None = None,
+    test_size: float | None = None,
+    return_indices: bool = False,
+    random_state: int = 0,
+) -> (
+    tuple[Sequence[str | Mol], Sequence[str | Mol], Sequence[Sequence[Any]]]
+    | tuple[Sequence, ...]
+    | tuple[Sequence[int], Sequence[int]]
+):
+    """
+    Split using MaxMin algorithm with stratification.
+
+    A variant of MaxMin split (see :py:func:`maxmin_train_test_split`), modified to
+    split each class separately. This preserves the relative class proportions in the
+    resulting train and test splits.
+
+    Note that results may differ quite strongly from regular MaxMin split, as here
+    classes are treated independently of each other. While the distances between
+    compounds in each class are maximized, there are no guarantees for the overall
+    dataset. However, generally this split should also result in relatively uniform
+    coverage of the entire chemical space.
+
+    Resulting sizes of train and test sets may differ slightly for very small datasets.
+    This is because each class is split separately with a given percentage.
+
+    If ``train_size`` and ``test_size`` are integers, they must sum up to the ``data``
+    length. If they are floating numbers, they must sum up to 1.
+
+    Parameters
+    ----------
+    data : sequence
+        A sequence representing either SMILES strings or RDKit ``Mol`` objects.
+
+    labels : array-like
+        An array or list with class labels as integers.
+
+    additional_data: list[sequence]
+        Additional sequences to be split alongside the main data (e.g., labels or feature vectors).
+
+    train_size : float, default=None
+        The fraction of data to be used for the train subset. If None, it is set to 1 - test_size.
+        If test_size is also None, it will be set to 0.8.
+
+    test_size : float, default=None
+        The fraction of data to be used for the test subset. If None, it is set to 1 - train_size.
+        If train_size is also None, it will be set to 0.2.
+
+    return_indices : bool, default=False
+        Whether the method should return the input object subsets, i.e. SMILES strings
+        or RDKit ``Mol`` objects, or only the indices of the subsets instead of the data.
+
+    random_state: int, default=0
+        Random generator seed that will be used for selecting initial molecules.
+
+    Returns
+    -------
+    subsets : tuple[list, list, ...]
+        Tuple with train-test subsets of provided arrays. First two are lists of SMILES
+        strings or RDKit ``Mol`` objects, depending on the input type. Third and fourth
+        are NumPy arrays with labels of train and test subsets. If `return_indices` is
+        True, lists of indices are returned instead of actual data as the first two
+        elements.
+
+    See Also
+    --------
+    :func:`maxmin_train_test_split` : Regular MaxMin split.
+    """
+    data_arr = np.array(data)
+    labels = np.array(labels, dtype=int)
+
+    train_idxs = []
+    test_idxs = []
+
+    for label in np.unique(labels):
+        label_idxs = np.nonzero(labels == label)[0]
+        label_data = data_arr[label_idxs]
+
+        # split indices of current label into train and test
+        # then map them to indices of the entire dataset
+        label_train_idxs, label_test_idxs = maxmin_train_test_split(
+            label_data,
+            train_size=train_size,
+            test_size=test_size,
+            return_indices=True,
+            random_state=random_state,
+        )
+        label_train_idxs = label_idxs[label_train_idxs].tolist()
+        label_test_idxs = label_idxs[label_test_idxs].tolist()
+
+        train_idxs.extend(label_train_idxs)
+        test_idxs.extend(label_test_idxs)
+
+    if return_indices:
+        train_subset = train_idxs
+        test_subset = test_idxs
+    else:
+        train_subset = get_data_from_indices(data, train_idxs)
+        test_subset = get_data_from_indices(data, test_idxs)
+
+    labels_train = labels[train_idxs]
+    labels_test = labels[test_idxs]
+
+    if additional_data:
+        additional_data_split: list[Sequence[Any]] = split_additional_data(
+            list(additional_data), train_idxs, test_idxs
+        )
+        return (
+            train_subset,
+            test_subset,
+            labels_train,
+            labels_test,
+            *additional_data_split,
+        )
+    else:
+        return train_subset, test_subset, labels_train, labels_test
+
+
+@validate_params(
+    {
+        "data": ["array-like"],
+        "labels": ["array-like"],
+        "additional_data": ["tuple"],
+        "train_size": [
+            Interval(RealNotInt, 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
+            None,
+        ],
+        "valid_size": [
+            Interval(RealNotInt, 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
+            None,
+        ],
+        "test_size": [
+            Interval(RealNotInt, 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
+            None,
+        ],
+        "return_indices": ["boolean"],
+    },
+    prefer_skip_nested_validation=True,
+)
+def maxmin_stratified_train_valid_test_split(
+    data: Sequence[str | Mol],
+    labels: np.ndarray | list[int] | pd.Series,
+    *additional_data: Sequence,
+    train_size: float | None = None,
+    valid_size: float | None = None,
+    test_size: float | None = None,
+    return_indices: bool = False,
+    random_state: int = 0,
+) -> (
+    tuple[Sequence[str | Mol], Sequence[str | Mol], Sequence[Sequence[Any]]]
+    | tuple[Sequence, ...]
+    | tuple[Sequence[int], Sequence[int]]
+):
+    """
+    Split using MaxMin algorithm with stratification.
+
+    A variant of MaxMin split (see :py:func:`maxmin_train_valid_test_split`), modified to
+    split each class separately. This preserves the relative class proportions in the
+    resulting train, valid, and test splits.
+
+    Note that results may differ quite strongly from regular MaxMin split, as here
+    classes are treated independently of each other. While the distances between
+    compounds in each class are maximized, there are no guarantees for the overall
+    dataset. However, generally this split should also result in relatively uniform
+    coverage of the entire chemical space.
+
+    Resulting sizes of train, valid, and test sets may differ slightly for very small
+    datasets. This is because each class is split separately with a given percentage.
+
+    If ``train_size``, ``valid_size`` and ``test_size`` are integers, they must sum up
+    to the ``data`` length. If they are floating numbers, they must sum up to 1.
+
+    Parameters
+    ----------
+    data : sequence
+        A sequence representing either SMILES strings or RDKit ``Mol`` objects.
+
+    labels : array-like
+        An array or list with class labels as integers.
+
+    additional_data: sequence
+        Additional sequences to be split alongside the main data, e.g. labels.
+
+    train_size : float, default=None
+        The fraction of data to be used for the train subset. If None, it is set
+        to 1 - test_size - valid_size. If valid_size is not provided, train_size
+        is set to 1 - test_size. If train_size, test_size and valid_size aren't
+        set, train_size is set to 0.8.
+
+    valid_size : float, default=None
+        The fraction of data to be used for the test subset. If None, it is set
+        to 1 - train_size - valid_size. If train_size, test_size and valid_size
+        aren't set, train_size is set to 0.1.
+
+    test_size : float, default=None
+        The fraction of data to be used for the validation subset. If None, it is
+        set to 1 - train_size - valid_size. If valid_size is not provided, test_size
+        is set to 1 - train_size. If train_size, test_size and valid_size aren't set,
+        test_size is set to 0.1.
+
+    return_indices : bool, default=False
+        Whether the method should return the input object subsets, i.e. SMILES strings
+        or RDKit ``Mol`` objects, or only the indices of the subsets instead of the data.
+
+    random_state: int, default=0
+        Random generator seed that will be used for selecting initial molecules.
+
+    Returns
+    -------
+    subsets : tuple[list, list, ...]
+        Tuple with train-valid-test subsets of provided arrays. First three are lists of
+        SMILES strings or RDKit ``Mol`` objects, depending on the input type. Next three
+        are NumPy arrays with labels of train-valid-test subsets. If `return_indices` is
+        True, lists of indices are returned instead of actual data as the first three
+        elements.
+
+    See Also
+    --------
+    :func:`maxmin_train_valid_test_split` : Regular MaxMin split.
+    """
+    data_arr = np.array(data)
+    labels = np.array(labels, dtype=int)
+
+    train_idxs = []
+    valid_idxs = []
+    test_idxs = []
+
+    for label in np.unique(labels):
+        label_idxs = np.nonzero(labels == label)[0]
+        label_data = data_arr[label_idxs]
+
+        # split indices of current label into train and test
+        # then map them to indices of the entire dataset
+        label_train_idxs, label_valid_idxs, label_test_idxs = (
+            maxmin_train_valid_test_split(
+                label_data,
+                train_size=train_size,
+                valid_size=valid_size,
+                test_size=test_size,
+                return_indices=True,
+                random_state=random_state,
+            )
+        )
+        label_train_idxs = label_idxs[label_train_idxs].tolist()
+        label_valid_idxs = label_idxs[label_valid_idxs].tolist()
+        label_test_idxs = label_idxs[label_test_idxs].tolist()
+
+        train_idxs.extend(label_train_idxs)
+        valid_idxs.extend(label_valid_idxs)
+        test_idxs.extend(label_test_idxs)
+
+    if return_indices:
+        train_subset = train_idxs
+        valid_subset = valid_idxs
+        test_subset = test_idxs
+    else:
+        train_subset = get_data_from_indices(data, train_idxs)
+        valid_subset = get_data_from_indices(data, valid_idxs)
+        test_subset = get_data_from_indices(data, test_idxs)
+
+    labels_train = labels[train_idxs]
+    labels_valid = labels[valid_idxs]
+    labels_test = labels[test_idxs]
+
+    if additional_data:
+        additional_data_split: list[Sequence[Any]] = split_additional_data(
+            list(additional_data), train_idxs, valid_idxs, test_idxs
+        )
+        return (
+            train_subset,
+            valid_subset,
+            test_subset,
+            labels_train,
+            labels_valid,
+            labels_test,
+            *additional_data_split,
+        )
+    else:
+        return (
+            train_subset,
+            valid_subset,
+            test_subset,
+            labels_train,
+            labels_valid,
+            labels_test,
+        )

--- a/tests/model_selection/splitters/maxmin_split.py
+++ b/tests/model_selection/splitters/maxmin_split.py
@@ -214,6 +214,40 @@ def test_maxmin_stratified_train_valid_test_split(mols_list):
     assert len(np.concatenate((y_train, y_valid, y_test))) == len(mols_list)
 
 
+def test_maxmin_stratified_train_test_split_return_indices(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+
+    train_set, test_set, train_labels, test_labels = maxmin_stratified_train_test_split(
+        mols_list, labels, train_size=0.7, test_size=0.3, return_indices=True
+    )
+
+    assert all(isinstance(train, int) for train in train_set)
+    assert all(isinstance(test, int) for test in test_set)
+
+    assert len(set(train_set) | set(test_set)) == len(mols_list)
+
+
+def test_maxmin_stratified_train_valid_test_split_returns_indices(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+
+    train_set, valid_set, test_set, train_labels, valid_labels, test_labels = (
+        maxmin_stratified_train_valid_test_split(
+            mols_list,
+            labels,
+            train_size=0.7,
+            test_size=0.2,
+            valid_size=0.1,
+            return_indices=True,
+        )
+    )
+
+    assert all(isinstance(train, int) for train in train_set)
+    assert all(isinstance(valid, int) for valid in valid_set)
+    assert all(isinstance(test, int) for test in test_set)
+
+    assert len(set(train_set) | set(valid_set) | set(test_set)) == len(mols_list)
+
+
 def test_maxmin_stratified_train_test_split_with_additional_data(mols_list):
     labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
     additional_data = ["a"] * len(mols_list)

--- a/tests/model_selection/splitters/maxmin_split.py
+++ b/tests/model_selection/splitters/maxmin_split.py
@@ -4,13 +4,15 @@ from rdkit import Chem
 from rdkit.Chem import Mol
 
 from skfp.model_selection.splitters.maxmin_split import (
+    maxmin_stratified_train_test_split,
+    maxmin_stratified_train_valid_test_split,
     maxmin_train_test_split,
     maxmin_train_valid_test_split,
 )
 
 
 @pytest.fixture
-def all_molecules() -> list[str]:
+def varied_mols() -> list[str]:
     return [
         "OCC3OC(OCC2OC(OC(C#N)c1ccccc1)C(O)C(O)C2O)C(O)C(O)C3O",
         "Cc1occc1C(=O)Nc2ccccc2",
@@ -25,25 +27,25 @@ def all_molecules() -> list[str]:
     ]
 
 
-def test_maxmin_split_size(all_molecules):
+def test_maxmin_split_size(varied_mols):
     train_set, test_set = maxmin_train_test_split(
-        all_molecules, train_size=0.7, test_size=0.3
+        varied_mols, train_size=0.7, test_size=0.3
     )
 
     assert len(train_set) == 7
     assert len(test_set) == 3
 
     train_set, test_set = maxmin_train_test_split(
-        all_molecules, train_size=0.6, test_size=0.4
+        varied_mols, train_size=0.6, test_size=0.4
     )
 
     assert len(train_set) == 6
     assert len(test_set) == 4
 
 
-def test_maxmin_valid_split_size(all_molecules):
+def test_maxmin_valid_split_size(varied_mols):
     train_set, valid_set, test_set = maxmin_train_valid_test_split(
-        all_molecules, train_size=0.7, test_size=0.2, valid_size=0.1
+        varied_mols, train_size=0.7, test_size=0.2, valid_size=0.1
     )
 
     assert len(train_set) == 7
@@ -51,7 +53,7 @@ def test_maxmin_valid_split_size(all_molecules):
     assert len(valid_set) == 1
 
     train_set, valid_set, test_set = maxmin_train_valid_test_split(
-        all_molecules, train_size=0.5, test_size=0.2, valid_size=0.3
+        varied_mols, train_size=0.5, test_size=0.2, valid_size=0.3
     )
 
     assert len(train_set) == 5
@@ -59,13 +61,13 @@ def test_maxmin_valid_split_size(all_molecules):
     assert len(valid_set) == 3
 
 
-def test_seed_consistency_train_valid_test_split(all_molecules):
+def test_seed_consistency_train_valid_test_split(varied_mols):
     train_set_1, valid_set_1, test_set_1 = maxmin_train_valid_test_split(
-        all_molecules, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
+        varied_mols, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
     )
 
     train_set_2, valid_set_2, test_set_2 = maxmin_train_valid_test_split(
-        all_molecules, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
+        varied_mols, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
     )
 
     assert train_set_1 == train_set_2
@@ -73,29 +75,31 @@ def test_seed_consistency_train_valid_test_split(all_molecules):
     assert test_set_1 == test_set_2
 
 
-def test_seed_consistency_train_test_split(all_molecules):
+def test_seed_consistency_train_test_split(varied_mols):
     train_set_1, test_set_1 = maxmin_train_test_split(
-        all_molecules, train_size=0.7, test_size=0.3, random_state=0
+        varied_mols, train_size=0.7, test_size=0.3, random_state=0
     )
 
     train_set_2, test_set_2 = maxmin_train_test_split(
-        all_molecules, train_size=0.7, test_size=0.3, random_state=0
+        varied_mols, train_size=0.7, test_size=0.3, random_state=0
     )
 
     assert train_set_1 == train_set_2
     assert test_set_1 == test_set_2
 
 
-def test_maxmin_train_test_split_return_molecules(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
+def test_maxmin_train_test_split_return_molecules(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
     train_set, test_set = maxmin_train_test_split(mols, train_size=0.7, test_size=0.3)
 
     assert all(isinstance(train, Mol) for train in train_set)
     assert all(isinstance(test, Mol) for test in test_set)
 
+    assert len(train_set + test_set) == len(mols)
 
-def test_maxmin_train_valid_test_split_returns_molecules(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
+
+def test_maxmin_train_valid_test_split_returns_molecules(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
     train_set, valid_set, test_set = maxmin_train_valid_test_split(
         mols,
         train_size=0.7,
@@ -108,9 +112,11 @@ def test_maxmin_train_valid_test_split_returns_molecules(all_molecules):
     assert all(isinstance(valid, Mol) for valid in valid_set)
     assert all(isinstance(test, Mol) for test in test_set)
 
+    assert len(train_set + valid_set + test_set) == len(mols)
 
-def test_maxmin_train_test_split_return_indices(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
+
+def test_maxmin_train_test_split_return_indices(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
     train_set, test_set = maxmin_train_test_split(
         mols, train_size=0.7, test_size=0.3, return_indices=True
     )
@@ -118,9 +124,11 @@ def test_maxmin_train_test_split_return_indices(all_molecules):
     assert all(isinstance(train, int) for train in train_set)
     assert all(isinstance(test, int) for test in test_set)
 
+    assert len(set(train_set) | set(test_set)) == len(varied_mols)
 
-def test_maxmin_train_valid_test_split_returns_indices(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
+
+def test_maxmin_train_valid_test_split_returns_indices(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
     train_set, valid_set, test_set = maxmin_train_valid_test_split(
         mols,
         train_size=0.7,
@@ -133,10 +141,12 @@ def test_maxmin_train_valid_test_split_returns_indices(all_molecules):
     assert all(isinstance(valid, int) for valid in valid_set)
     assert all(isinstance(test, int) for test in test_set)
 
+    assert len(set(train_set) | set(valid_set) | set(test_set)) == len(varied_mols)
 
-def test_maxmin_train_test_split_with_additional_data(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
-    labels = np.ones(len(all_molecules))
+
+def test_maxmin_train_test_split_with_additional_data(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    labels = np.ones(len(varied_mols))
     train_mols, test_mols, train_labels, test_labels = maxmin_train_test_split(
         mols, labels
     )
@@ -145,9 +155,9 @@ def test_maxmin_train_test_split_with_additional_data(all_molecules):
     assert len(test_mols) == len(test_labels)
 
 
-def test_maxmin_train_valid_test_split_with_additional_data(all_molecules):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
-    labels = np.ones(len(all_molecules))
+def test_maxmin_train_valid_test_split_with_additional_data(varied_mols):
+    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    labels = np.ones(len(varied_mols))
     train_mols, valid_mols, test_mols, train_labels, valid_labels, test_labels = (
         maxmin_train_valid_test_split(mols, labels)
     )
@@ -155,3 +165,97 @@ def test_maxmin_train_valid_test_split_with_additional_data(all_molecules):
     assert len(train_mols) == len(train_labels)
     assert len(valid_mols) == len(valid_labels)
     assert len(test_mols) == len(test_labels)
+
+
+def test_maxmin_stratified_train_test_split(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+
+    mols_train, mols_test, y_train, y_test = maxmin_stratified_train_test_split(
+        mols_list, labels, train_size=0.7, test_size=0.3
+    )
+
+    assert len(mols_train) == int(0.7 * len(mols_list))
+    assert len(mols_test) == int(0.3 * len(mols_list))
+    assert len(mols_train + mols_test) == len(mols_list)
+
+    assert len(mols_train) == len(y_train)
+    assert len(mols_test) == len(y_test)
+
+    assert np.isclose(y_train.mean(), 0.5)
+    assert np.isclose(y_test.mean(), 0.5)
+    assert len(np.concatenate((y_train, y_test))) == len(mols_list)
+
+
+def test_maxmin_stratified_train_valid_test_split(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+
+    mols_train, mols_valid, mols_test, y_train, y_valid, y_test = (
+        maxmin_stratified_train_valid_test_split(
+            mols_list,
+            labels,
+            train_size=0.7,
+            valid_size=0.1,
+            test_size=0.2,
+        )
+    )
+
+    assert len(mols_train) == int(0.7 * len(mols_list))
+    assert len(mols_valid) == int(0.1 * len(mols_list))
+    assert len(mols_test) == int(0.2 * len(mols_list))
+    assert len(mols_train + mols_valid + mols_test) == len(mols_list)
+
+    assert len(mols_train) == len(y_train)
+    assert len(mols_valid) == len(y_valid)
+    assert len(mols_test) == len(y_test)
+
+    assert np.isclose(y_train.mean(), 0.5)
+    assert np.isclose(y_valid.mean(), 0.5)
+    assert np.isclose(y_test.mean(), 0.5)
+    assert len(np.concatenate((y_train, y_valid, y_test))) == len(mols_list)
+
+
+def test_maxmin_stratified_train_test_split_with_additional_data(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+    additional_data = ["a"] * len(mols_list)
+
+    (
+        train_mols,
+        test_mols,
+        train_labels,
+        test_labels,
+        train_additional_data,
+        test_additional_data,
+    ) = maxmin_stratified_train_test_split(
+        mols_list, labels, additional_data, test_size=0.2
+    )
+
+    assert len(train_mols) == len(train_labels) == len(train_additional_data)
+    assert len(test_mols) == len(test_labels) == len(test_additional_data)
+
+
+def test_maxmin_stratified_train_valid_test_split_with_additional_data(mols_list):
+    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
+    additional_data = ["a"] * len(mols_list)
+
+    (
+        train_mols,
+        valid_mols,
+        test_mols,
+        train_labels,
+        valid_labels,
+        test_labels,
+        train_additional_data,
+        valid_additional_data,
+        test_additional_data,
+    ) = maxmin_stratified_train_valid_test_split(
+        mols_list,
+        labels,
+        additional_data,
+        train_size=0.7,
+        valid_size=0.1,
+        test_size=0.2,
+    )
+
+    assert len(train_mols) == len(train_labels) == len(train_additional_data)
+    assert len(valid_mols) == len(valid_labels) == len(valid_additional_data)
+    assert len(test_mols) == len(test_labels) == len(test_additional_data)


### PR DESCRIPTION
## Changes

Adds a stratified variant of MaxMin split (https://github.com/scikit-fingerprints/scikit-fingerprints/issues/449), which keeps the same class proportions after splitting.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
