### PR TITLE
Filter condition indicators for physicochemical filters

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -124,13 +124,13 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
         feature_names_out : ndarray of str objects
             Filter condition names.
         """
-        if not hasattr(self, "_feature_names"):
+        if not hasattr(self, "_condition_names"):
             raise AttributeError(
                 f"Filter condition names not yet supported for "
                 f"{self.__class__.__name__}"
             )
 
-        return np.array(self._feature_names)
+        return np.array(self._condition_names)
 
     def fit(self, X: Sequence[str | Mol], y: np.ndarray | None = None):
         """Unused, kept for scikit-learn compatibility.

--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from copy import deepcopy
@@ -7,7 +8,7 @@ import numpy as np
 from joblib import effective_n_jobs
 from rdkit.Chem import Mol
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils._param_validation import InvalidParameterError
+from sklearn.utils._param_validation import InvalidParameterError, StrOptions
 from tqdm import tqdm
 
 from skfp.utils import ensure_mols, run_in_parallel
@@ -37,9 +38,21 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. ``"mol"`` returns list of
+        molecules passing the filter. ``"indicators"`` returns a binary vector with
+        indicators which molecules pass the filter. ``"condition_indicators"`` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -60,6 +73,7 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
     # parameters common for all filters
     _parameter_constraints: dict = {
         "allow_one_violation": ["boolean"],
+        "return_type": [StrOptions({"mol", "indicators", "condition_indicators"})],
         "return_indicators": ["boolean"],
         "n_jobs": [Integral, None],
         "batch_size": [Integral, None],
@@ -69,16 +83,24 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
     ):
         self.allow_one_violation = allow_one_violation
+        self.return_type = return_type
         self.return_indicators = return_indicators
         self.n_jobs = n_jobs
         self.batch_size = batch_size
         self.verbose = verbose
+
+        if return_indicators:
+            warnings.warn(
+                "return_indicators is deprecated and will be removed in 2.0, "
+                "use return_type instead"
+            )
 
     def __sklearn_is_fitted__(self) -> bool:
         """
@@ -86,6 +108,29 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
         transformers and always returns True.
         """
         return True
+
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        """
+        Get filter condition names. They correspond to molecular descriptors (for
+        physicochemical filters) or SMARTS patterns (for substructural filters).
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Unused, kept for scikit-learn compatibility.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Filter condition names.
+        """
+        if not hasattr(self, "_feature_names"):
+            raise AttributeError(
+                f"Filter condition names not yet supported for "
+                f"{self.__class__.__name__}"
+            )
+
+        return np.array(self._feature_names)
 
     def fit(self, X: Sequence[str | Mol], y: np.ndarray | None = None):
         """Unused, kept for scikit-learn compatibility.
@@ -133,40 +178,43 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
         self, X: Sequence[str | Mol], copy: bool = False
     ) -> list[str | Mol] | np.ndarray:
         """
-        Apply a filter to input molecules. Output depends on ``return_indicators``
+        Apply a filter to input molecules. Output depends on ``return_type``
         attribute.
 
         Parameters
         ----------
-        X : {sequence, array-like} of shape (n_samples,)
-            Sequence containing RDKit ``Mol`` objects.
+        X : {sequence of str or Mol}
+            Sequence containing SMILES strings or RDKit ``Mol`` objects.
 
         copy : bool, default=False
             Copy the input X or not.
 
         Returns
         -------
-        X : list of shape (n_samples_conf_gen,) or array of shape (n_samples,)
-            List with filtered molecules, or indicator vector which molecules
-            fulfill the filter rules.
+        X : list of shape (n_samples,) or array of shape (n_samples,)
+            or array of shape (n_samples, n_conditions)
+            List with filtered molecules or indicators.
         """
         filter_ind = self._get_filter_indicators(X, copy)
+
         if self.return_indicators:
             return filter_ind
-        else:
+        elif self.return_type == "mol":
             return [mol for idx, mol in enumerate(X) if filter_ind[idx]]
+        else:
+            return filter_ind
 
     def transform_x_y(
         self, X: Sequence[str | Mol], y: np.ndarray, copy: bool = False
     ) -> tuple[list[str | Mol], np.ndarray] | tuple[np.ndarray, np.ndarray]:
         """
-        Apply a filter to input molecules. Output depends on ``return_indicators``
+        Apply a filter to input molecules. Output depends on ``return_type``
         attribute.
 
         Parameters
         ----------
-        X : {sequence, array-like} of shape (n_samples,)
-            Sequence containing RDKit ``Mol`` objects.
+        X : {sequence of str or Mol}
+            Sequence containing SMILES strings or RDKit ``Mol`` objects.
 
         y : array-like of shape (n_samples,)
             Array with labels for molecules.
@@ -176,27 +224,29 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        X : list of shape (n_samples_conf_gen,) or array of shape (n_samples,)
-            List with filtered molecules, or indicator vector which molecules
-            fulfill the filter rules.
+        X : list of shape (n_samples,) or array of shape (n_samples,)
+            or array of shape (n_samples, n_conditions)
+            List with filtered molecules or indicators.
 
-        y : np.ndarray of shape (n_samples_conf_gen,)
+        y : np.ndarray of shape (n_samples,)
             Array with labels for molecules.
         """
         filter_ind = self._get_filter_indicators(X, copy)
+
         if self.return_indicators:
             return filter_ind, y
-        else:
+        elif self.return_type == "mol":
             mols = [mol for idx, mol in enumerate(X) if filter_ind[idx]]
             y = y[filter_ind]
             return mols, y
+        else:
+            return filter_ind, y
 
     def _get_filter_indicators(
         self, mols: Sequence[str | Mol], copy: bool
     ) -> np.ndarray:
         self._validate_params()
         mols = deepcopy(mols) if copy else mols
-        mols = ensure_mols(mols)
 
         n_jobs = effective_n_jobs(self.n_jobs)
         if n_jobs == 1:
@@ -207,23 +257,38 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
             else:
                 filter_indicators = self._filter_mols_batch(mols)
         else:
+            flatten_results = self.return_type != "condition_indicators"
+
             filter_indicators = run_in_parallel(
                 self._filter_mols_batch,
                 data=mols,
                 n_jobs=n_jobs,
                 batch_size=self.batch_size,
-                flatten_results=True,
+                flatten_results=flatten_results,
                 verbose=self.verbose,
             )
 
+        if self.return_type == "condition_indicators":
+            filter_indicators = np.vstack(filter_indicators)
+
         return filter_indicators
 
-    def _filter_mols_batch(self, mols: list[Mol]) -> np.ndarray:
+    def _filter_mols_batch(self, mols: Sequence[str | Mol]) -> np.ndarray:
+        mols = ensure_mols(mols)
+
         filter_indicators = [self._apply_mol_filter(mol) for mol in mols]
-        return np.array(filter_indicators, dtype=bool)
+
+        if self.return_indicators:
+            filter_indicators = np.array(filter_indicators, dtype=bool)
+        elif self.return_type == "condition_indicators":
+            filter_indicators = np.vstack(filter_indicators)
+        else:
+            filter_indicators = np.array(filter_indicators, dtype=bool)
+
+        return filter_indicators
 
     @abstractmethod
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         pass
 
     def _validate_params(self) -> None:

--- a/skfp/filters/beyond_ro5.py
+++ b/skfp/filters/beyond_ro5.py
@@ -113,7 +113,7 @@ class BeyondRo5Filter(BaseFilter):
             "HBA <= 15",
             "HBD <= 6",
             "TPSA <= 250",
-            "NumRotatableBonds <= 6",
+            "rotatable bonds <= 6",
         ]
 
     def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:

--- a/skfp/filters/beyond_ro5.py
+++ b/skfp/filters/beyond_ro5.py
@@ -49,6 +49,11 @@ class BeyondRo5Filter(BaseFilter):
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
 
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
+
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
         :meth:`transform` are parallelized over the input molecules. ``None`` means 1
@@ -107,7 +112,7 @@ class BeyondRo5Filter(BaseFilter):
             batch_size=batch_size,
             verbose=verbose,
         )
-        self._feature_names = [
+        self._condition_names = [
             "MolWeight <= 1000",
             "-2 <= logP <= 10",
             "HBA <= 15",

--- a/skfp/filters/beyond_ro5.py
+++ b/skfp/filters/beyond_ro5.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -36,6 +37,13 @@ class BeyondRo5Filter(BaseFilter):
     allow_one_violation : bool, default=False
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
+
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
 
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
@@ -85,6 +93,7 @@ class BeyondRo5Filter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -92,13 +101,22 @@ class BeyondRo5Filter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._feature_names = [
+            "MolWeight <= 1000",
+            "-2 <= logP <= 10",
+            "HBA <= 15",
+            "HBD <= 6",
+            "TPSA <= 250",
+            "NumRotatableBonds <= 6",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             MolWt(mol) <= 1000,
             -2 <= MolLogP(mol) <= 10,
@@ -107,6 +125,10 @@ class BeyondRo5Filter(BaseFilter):
             CalcTPSA(mol) <= 250,
             CalcNumRotatableBonds(mol) <= 20,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/faf4_druglike.py
+++ b/skfp/filters/faf4_druglike.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import GetFormalCharge, Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -77,6 +78,8 @@ class FAF4DruglikeFilter(BaseFilter):
 
     verbose : int, default=0
         Controls the verbosity when filtering molecules.
+        If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
+        and can be used to control the progress bar.
 
     References
     ----------
@@ -108,6 +111,7 @@ class FAF4DruglikeFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -115,13 +119,30 @@ class FAF4DruglikeFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._feature_names = [
+            "100 <= MolWeight <= 600",
+            "-3 <= logP <= 6",
+            "HBA <= 12",
+            "HBD <= 7",
+            "TPSA <= 180",
+            "rotatable bonds <= 11",
+            "rigid bonds <= 30",
+            "rings <= 6",
+            "max ring size <= 18",
+            "3 <= carbon atoms <= 35",
+            "1 <= heteroatoms <= 15",
+            "0.1 <= non-carbon-carbon ratio <= 1.1",
+            "charged functional groups <= 4",
+            "-4 <= formal charge <= 4",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             100 <= MolWt(mol) <= 600,
             -3 <= MolLogP(mol) <= 6,
@@ -138,6 +159,10 @@ class FAF4DruglikeFilter(BaseFilter):
             get_num_charged_functional_groups(mol) <= 4,
             -4 <= GetFormalCharge(mol) <= 4,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/faf4_druglike.py
+++ b/skfp/filters/faf4_druglike.py
@@ -62,6 +62,13 @@ class FAF4DruglikeFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.

--- a/skfp/filters/faf4_druglike.py
+++ b/skfp/filters/faf4_druglike.py
@@ -73,6 +73,11 @@ class FAF4DruglikeFilter(BaseFilter):
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
 
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
+
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
         :meth:`transform` are parallelized over the input molecules. ``None`` means 1
@@ -132,7 +137,7 @@ class FAF4DruglikeFilter(BaseFilter):
             batch_size=batch_size,
             verbose=verbose,
         )
-        self._feature_names = [
+        self._condition_names = [
             "100 <= MolWeight <= 600",
             "-3 <= logP <= 6",
             "HBA <= 12",
@@ -144,7 +149,7 @@ class FAF4DruglikeFilter(BaseFilter):
             "max ring size <= 18",
             "3 <= carbon atoms <= 35",
             "1 <= heteroatoms <= 15",
-            "0.1 <= non-carbon-carbon ratio <= 1.1",
+            "0.1 <= non-carbon to carbon ratio <= 1.1",
             "charged functional groups <= 4",
             "-4 <= formal charge <= 4",
         ]

--- a/skfp/filters/faf4_druglike.py
+++ b/skfp/filters/faf4_druglike.py
@@ -114,7 +114,11 @@ class FAF4DruglikeFilter(BaseFilter):
         verbose: int = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/faf4_leadlike.py
+++ b/skfp/filters/faf4_leadlike.py
@@ -115,7 +115,11 @@ class FAF4LeadlikeFilter(BaseFilter):
         verbose: int = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/faf4_leadlike.py
+++ b/skfp/filters/faf4_leadlike.py
@@ -74,6 +74,11 @@ class FAF4LeadlikeFilter(BaseFilter):
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
 
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
+
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
         :meth:`transform` are parallelized over the input molecules. ``None`` means 1
@@ -131,7 +136,7 @@ class FAF4LeadlikeFilter(BaseFilter):
             batch_size=batch_size,
             verbose=verbose,
         )
-        self._feature_names = [
+        self._condition_names = [
             "150 <= MolWeight <= 400",
             "-3 <= logP <= 4",
             "HBA <= 7",
@@ -143,7 +148,7 @@ class FAF4LeadlikeFilter(BaseFilter):
             "max ring size <= 18",
             "3 <= carbon atoms <= 35",
             "1 <= heteroatoms <= 15",
-            "0.1 <= non-carbon-carbon ratio <= 1.1",
+            "0.1 <= non-carbon to carbon ratio <= 1.1",
             "charged functional groups <= 4",
             "-4 <= formal charge <= 4",
             "stereocenters <= 2",

--- a/skfp/filters/faf4_leadlike.py
+++ b/skfp/filters/faf4_leadlike.py
@@ -63,6 +63,13 @@ class FAF4LeadlikeFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.

--- a/skfp/filters/ghose.py
+++ b/skfp/filters/ghose.py
@@ -36,6 +36,11 @@ class GhoseFilter(BaseFilter):
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
 
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
+
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
         :meth:`transform` are parallelized over the input molecules. ``None`` means 1
@@ -89,7 +94,7 @@ class GhoseFilter(BaseFilter):
             batch_size=batch_size,
             verbose=verbose,
         )
-        self._feature_names = [
+        self._condition_names = [
             "160 <= MolWeight <= 400",
             "-0.4 <= logP <= 5.6",
             "20 <= atoms <= 70",

--- a/skfp/filters/gsk.py
+++ b/skfp/filters/gsk.py
@@ -1,4 +1,7 @@
-from rdkit.Chem import Crippen, Mol, rdMolDescriptors
+import numpy as np
+from rdkit.Chem import Mol
+from rdkit.Chem.Crippen import MolLogP
+from rdkit.Chem.Descriptors import MolWt
 
 from skfp.bases.base_filter import BaseFilter
 
@@ -11,7 +14,7 @@ class GSKFilter(BaseFilter):
 
     Molecule must fulfill conditions:
 
-    - molecular weight <= 400
+    - molecular weight <= 400 daltons
     - logP <= 4
 
     Parameters
@@ -20,9 +23,21 @@ class GSKFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -59,6 +74,7 @@ class GSKFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -66,17 +82,25 @@ class GSKFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
-
-    def _apply_mol_filter(self, mol: Mol) -> bool:
-        rules = [
-            rdMolDescriptors.CalcExactMolWt(mol) <= 400,
-            Crippen.MolLogP(mol) <= 4,
+        self._condition_names = [
+            "MolWeight <= 400",
+            "logP <= 4",
         ]
+
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
+        rules = [
+            MolWt(mol) <= 400,
+            MolLogP(mol) <= 4,
+        ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/gsk.py
+++ b/skfp/filters/gsk.py
@@ -65,7 +65,11 @@ class GSKFilter(BaseFilter):
         verbose: int = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/hao.py
+++ b/skfp/filters/hao.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -23,16 +24,27 @@ class HaoFilter(BaseFilter):
     - number of rotatable bonds <= 9
     - number of aromatic bonds <= 17
 
-
     Parameters
     ----------
     allow_one_violation : bool, default=False
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -72,6 +84,7 @@ class HaoFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -79,13 +92,22 @@ class HaoFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "MolWeight <= 435",
+            "logP <= 6",
+            "HBD <= 2",
+            "HBA <= 6",
+            "rotatable bonds <= 9",
+            "aromatic bonds <= 17",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         aromatic_bond_count = sum(
             bond.GetBondType() == BondType.AROMATIC for bond in mol.GetBonds()
         )
@@ -97,6 +119,9 @@ class HaoFilter(BaseFilter):
             CalcNumRotatableBonds(mol) <= 9,
             aromatic_bond_count <= 17,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/lipinski.py
+++ b/skfp/filters/lipinski.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -16,7 +17,7 @@ class LipinskiFilter(BaseFilter):
 
     Molecule can violate at most one of the rules (conditions):
 
-    - molecular weight <= 500 daltons
+    - molecular weight <= 500
     - HBA <= 10
     - HBD <= 5
     - logP <= 5
@@ -31,9 +32,21 @@ class LipinskiFilter(BaseFilter):
         filter less restrictive, and is the part of the original definition of this
         filter.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -74,6 +87,7 @@ class LipinskiFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = True,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -81,19 +95,30 @@ class LipinskiFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
-
-    def _apply_mol_filter(self, mol: Mol) -> bool:
-        rules = [
-            MolWt(mol) <= 500,  # molecular weight
-            CalcNumLipinskiHBA(mol) <= 10,  # HBA
-            CalcNumLipinskiHBD(mol) <= 5,  # HBD
-            MolLogP(mol) <= 5,  # logP
+        self._condition_names = [
+            "MolWeight <= 500",
+            "HBA <= 10",
+            "HBD <= 5",
+            "logP <= 5",
         ]
+
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
+        rules = [
+            MolWt(mol) <= 500,
+            CalcNumLipinskiHBA(mol) <= 10,
+            CalcNumLipinskiHBD(mol) <= 5,
+            MolLogP(mol) <= 5,
+        ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/mol_weight.py
+++ b/skfp/filters/mol_weight.py
@@ -1,5 +1,6 @@
 from numbers import Integral
 
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Descriptors import MolWt
 from sklearn.utils._param_validation import Interval, InvalidParameterError
@@ -11,20 +12,32 @@ class MolecularWeightFilter(BaseFilter):
     """
     Molecular weight filter.
 
-    Filters out molecules with mass in Daltons outside the given range. Provided
+    Filters out molecules with mass in daltons outside the given range. Provided
     ``min_weight`` and ``max_weight`` are inclusive on both sides.
 
     Parameters
     ----------
     min_weight : int, default=0
-        Minimal weight in Daltons.
+        Minimal weight in daltons.
 
     max_weight : int, default=1000
-        Maximal weight in Daltons.
+        Maximal weight in daltons.
+
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
 
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -65,11 +78,13 @@ class MolecularWeightFilter(BaseFilter):
         min_weight: int = 0,
         max_weight: int = 1000,
         return_indicators: bool = False,
+        return_type: str = "mol",
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
     ):
         super().__init__(
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
@@ -77,6 +92,7 @@ class MolecularWeightFilter(BaseFilter):
         )
         self.min_weight = min_weight
         self.max_weight = max_weight
+        self._condition_names = [f"{min_weight} <= MolWeight <= {max_weight}"]
 
     def _validate_params(self) -> None:
         super()._validate_params()
@@ -87,5 +103,10 @@ class MolecularWeightFilter(BaseFilter):
                 f"min_weight={self.min_weight}, max_weight={self.max_weight}"
             )
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
-        return self.min_weight <= MolWt(mol) <= self.max_weight
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
+        passed = self.min_weight <= MolWt(mol) <= self.max_weight
+
+        if self.return_type == "condition_indicators":
+            passed = np.array([passed], dtype=bool).reshape(-1, 1)
+
+        return passed

--- a/skfp/filters/oprea.py
+++ b/skfp/filters/oprea.py
@@ -68,7 +68,11 @@ class OpreaFilter(BaseFilter):
         verbose: int = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/oprea.py
+++ b/skfp/filters/oprea.py
@@ -1,4 +1,11 @@
-from rdkit.Chem import Mol, rdMolDescriptors
+import numpy as np
+from rdkit.Chem import Mol
+from rdkit.Chem.rdMolDescriptors import (
+    CalcNumHBA,
+    CalcNumHBD,
+    CalcNumRings,
+    CalcNumRotatableBonds,
+)
 
 from skfp.bases.base_filter import BaseFilter
 
@@ -12,7 +19,7 @@ class OpreaFilter(BaseFilter):
 
     Molecule must fulfill conditions:
 
-    - HBD in range [0, 2]
+    - HBD <= 2
     - HBA in range [2, 9]
     - number of rotatable bonds in range [2, 8]
     - number of rings in range [1, 4]
@@ -23,9 +30,21 @@ class OpreaFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -62,6 +81,7 @@ class OpreaFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -69,19 +89,29 @@ class OpreaFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
-
-    def _apply_mol_filter(self, mol: Mol) -> bool:
-        rules = [
-            0 <= rdMolDescriptors.CalcNumHBD(mol) <= 2,
-            2 <= rdMolDescriptors.CalcNumHBA(mol) <= 9,
-            2 <= rdMolDescriptors.CalcNumRotatableBonds(mol) <= 8,
-            1 <= rdMolDescriptors.CalcNumRings(mol) <= 4,
+        self._condition_names = [
+            "HBD <= 2",
+            "2 <= HBA <= 9",
+            "2 <= rotatable bonds <= 8",
+            "1 <= rings <= 4",
         ]
+
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
+        rules = [
+            CalcNumHBD(mol) <= 2,
+            2 <= CalcNumHBA(mol) <= 9,
+            2 <= CalcNumRotatableBonds(mol) <= 8,
+            1 <= CalcNumRings(mol) <= 4,
+        ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/pfizer.py
+++ b/skfp/filters/pfizer.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.rdMolDescriptors import CalcTPSA
@@ -24,9 +25,21 @@ class PfizerFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -71,6 +84,7 @@ class PfizerFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -78,17 +92,26 @@ class PfizerFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "logP <= 3",
+            "TPSA >= 75",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             MolLogP(mol) <= 3,
             CalcTPSA(mol) >= 75,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/reos.py
+++ b/skfp/filters/reos.py
@@ -73,7 +73,12 @@ class REOSFilter(BaseFilter):
         verbose: int | dict = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_type="mol",  # currently unused,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/rule_of_four.py
+++ b/skfp/filters/rule_of_four.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -15,7 +16,7 @@ class RuleOfFourFilter(BaseFilter):
 
     Molecule must fulfill conditions:
 
-    - molecular weight >= 400 daltons
+    - molecular weight >= 400
     - HBA >= 4
     - logP >=4
     - number of rings >= 4
@@ -26,9 +27,21 @@ class RuleOfFourFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. `"mol"` returns list of
+        molecules passing the filter. `"indicators"` returns a binary vector with
+        indicators which molecules pass the filter. `"condition_indicators"` returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -68,6 +81,7 @@ class RuleOfFourFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -75,19 +89,29 @@ class RuleOfFourFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "MolWeight >= 400",
+            "logP >= 4",
+            "HBA >= 4",
+            "rings >= 4",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             MolWt(mol) >= 400,
             MolLogP(mol) >= 4,
             CalcNumHBA(mol) >= 4,
             CalcNumRings(mol) >= 4,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/rule_of_two.py
+++ b/skfp/filters/rule_of_two.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -14,7 +15,7 @@ class RuleOfTwoFilter(BaseFilter):
 
     Molecule must fulfill conditions:
 
-    - molecular weight <= 200 daltons
+    - molecular weight <= 200
     - HBA <= 4
     - HBD <= 2
     - logP <= 2
@@ -25,9 +26,21 @@ class RuleOfTwoFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -66,6 +79,7 @@ class RuleOfTwoFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -73,19 +87,30 @@ class RuleOfTwoFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "MolWeight <= 200",
+            "HBA <= 4",
+            "HBD <= 2",
+            "logP <= 2",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             MolWt(mol) <= 200,
             CalcNumHBA(mol) <= 4,
             CalcNumHBD(mol) <= 2,
             MolLogP(mol) <= 2,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/rule_of_veber.py
+++ b/skfp/filters/rule_of_veber.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol, rdMolDescriptors
 
 from skfp.bases.base_filter import BaseFilter
@@ -22,9 +23,21 @@ class RuleOfVeberFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -63,6 +76,7 @@ class RuleOfVeberFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -70,17 +84,25 @@ class RuleOfVeberFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "rotatable bonds <= 10",
+            "TPSA <= 140",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             rdMolDescriptors.CalcNumRotatableBonds(mol) <= 10,
             rdMolDescriptors.CalcTPSA(mol) <= 140,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/rule_of_veber.py
+++ b/skfp/filters/rule_of_veber.py
@@ -69,7 +69,11 @@ class RuleOfVeberFilter(BaseFilter):
         verbose: int | dict = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/rule_of_xu.py
+++ b/skfp/filters/rule_of_xu.py
@@ -70,7 +70,11 @@ class RuleOfXuFilter(BaseFilter):
         verbose: int | dict = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/rule_of_xu.py
+++ b/skfp/filters/rule_of_xu.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol, rdMolDescriptors
 
 from skfp.bases.base_filter import BaseFilter
@@ -23,9 +24,21 @@ class RuleOfXuFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -64,6 +77,7 @@ class RuleOfXuFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -71,13 +85,21 @@ class RuleOfXuFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "HBD <= 5",
+            "HBA <= 10",
+            "2 <= rotatable bonds <= 35",
+            "1 <= rings <= 7",
+            "10 <= heavy atoms <= 50",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             rdMolDescriptors.CalcNumHBD(mol) <= 5,
             rdMolDescriptors.CalcNumHBA(mol) <= 10,
@@ -85,6 +107,9 @@ class RuleOfXuFilter(BaseFilter):
             1 <= rdMolDescriptors.CalcNumRings(mol) <= 7,
             10 <= rdMolDescriptors.CalcNumHeavyAtoms(mol) <= 50,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
 
         passed_rules = sum(rules)
 

--- a/skfp/filters/tice_herbicides.py
+++ b/skfp/filters/tice_herbicides.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -27,9 +28,21 @@ class TiceHerbicidesFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a NumPy array with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -70,6 +83,7 @@ class TiceHerbicidesFilter(BaseFilter):
         self,
         allow_one_violation: bool = False,
         return_indicators: bool = False,
+        return_type: str = "mol",
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
@@ -77,12 +91,20 @@ class TiceHerbicidesFilter(BaseFilter):
         super().__init__(
             allow_one_violation=allow_one_violation,
             return_indicators=return_indicators,
+            return_type=return_type,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "150 <= MolWeight <= 500",
+            "logP <= 3.5",
+            "HBD <= 3",
+            "2 <= HBA <= 12",
+            "rotatable bonds <= 11",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             150 <= MolWt(mol) <= 500,
             MolLogP(mol) <= 3.5,
@@ -90,6 +112,10 @@ class TiceHerbicidesFilter(BaseFilter):
             2 <= CalcNumHBA(mol) <= 12,
             CalcNumRotatableBonds(mol) <= 11,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/valence_discovery.py
+++ b/skfp/filters/valence_discovery.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import GetFormalCharge, Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -56,9 +57,21 @@ class ValenceDiscoveryFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a NumPy array with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            ``return_indicators`` is deprecated and will be removed in version 2.0.
+            Use ``return_type`` instead. If ``return_indicators`` is set to ``True``,
+            it will take precedence over ``return_type``.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -95,6 +108,7 @@ class ValenceDiscoveryFilter(BaseFilter):
         self,
         allow_one_violation: bool = False,
         return_indicators: bool = False,
+        return_type: str = "mol",
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int = 0,
@@ -102,12 +116,31 @@ class ValenceDiscoveryFilter(BaseFilter):
         super().__init__(
             allow_one_violation=allow_one_violation,
             return_indicators=return_indicators,
+            return_type=return_type,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "200 <= MolWeight <= 600",
+            "-3 <= logP <= 6",
+            "HBA <= 12",
+            "HBD <= 7",
+            "40 <= TPSA <= 180",
+            "rotatable bonds <= 15",
+            "rigid bonds <= 30",
+            "aromatic rings <= 5",
+            "fused aromatic rings <= 2",
+            "max ring size <= 18",
+            "heavy atoms < 70",
+            "heavy metals < 1",
+            "3 <= carbon atoms <= 40",
+            "1 <= heteroatoms <= 15",
+            "-2 <= formal charge <= 2",
+            "charged atoms <= 2",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             200 <= MolWt(mol) <= 600,
             -3 <= MolLogP(mol) <= 6,
@@ -126,6 +159,10 @@ class ValenceDiscoveryFilter(BaseFilter):
             -2 <= GetFormalCharge(mol) <= 2,
             get_num_charged_atoms(mol) <= 2,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/filters/valence_discovery.py
+++ b/skfp/filters/valence_discovery.py
@@ -100,7 +100,11 @@ class ValenceDiscoveryFilter(BaseFilter):
         verbose: int = 0,
     ):
         super().__init__(
-            allow_one_violation, return_indicators, n_jobs, batch_size, verbose
+            allow_one_violation=allow_one_violation,
+            return_indicators=return_indicators,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            verbose=verbose,
         )
 
     def _apply_mol_filter(self, mol: Mol) -> bool:

--- a/skfp/filters/zinc_druglike.py
+++ b/skfp/filters/zinc_druglike.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import GetFormalCharge, Mol
 from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.Descriptors import MolWt
@@ -50,9 +51,21 @@ class ZINCDruglikeFilter(BaseFilter):
         Whether to allow violating one of the rules for a molecule. This makes the
         filter less restrictive.
 
+    return_type : {"mol", "indicators", "condition_indicators"}, default="mol"
+        What values to return as the filtering result. "mol" returns list of
+        molecules passing the filter. "indicators" returns a binary vector with
+        indicators which molecules pass the filter. "condition_indicators" returns
+        a Pandas DataFrame with molecules in rows, filter conditions in columns, and
+        0/1 indicators whether a given condition was fulfilled by a given molecule.
+
     return_indicators : bool, default=False
         Whether to return a binary vector with indicators which molecules pass the
         filter, instead of list of molecules.
+
+        .. deprecated:: 1.17
+            return_indicators is deprecated and will be removed in version 2.0.
+            Use return_type instead. If return_indicators is set to True,
+            it will take precedence over return_type.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`transform_x_y` and
@@ -93,6 +106,7 @@ class ZINCDruglikeFilter(BaseFilter):
     def __init__(
         self,
         allow_one_violation: bool = False,
+        return_type: str = "mol",
         return_indicators: bool = False,
         n_jobs: int | None = None,
         batch_size: int | None = None,
@@ -100,13 +114,29 @@ class ZINCDruglikeFilter(BaseFilter):
     ):
         super().__init__(
             allow_one_violation=allow_one_violation,
+            return_type=return_type,
             return_indicators=return_indicators,
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
         )
+        self._condition_names = [
+            "60 <= MolWeight <= 600",
+            "-4 <= logP <= 6",
+            "HBA <= 11",
+            "HBD <= 6",
+            "TPSA <= 150",
+            "rotatable bonds <= 12",
+            "rigid bonds <= 50",
+            "rings <= 7",
+            "max ring size <= 12",
+            "carbon atoms >= 3",
+            "non-carbon to carbon ratio <= 2.0",
+            "charged functional groups <= 4",
+            "-4 <= formal charge <= 4",
+        ]
 
-    def _apply_mol_filter(self, mol: Mol) -> bool:
+    def _apply_mol_filter(self, mol: Mol) -> bool | np.ndarray:
         rules = [
             60 <= MolWt(mol) <= 600,
             -4 <= MolLogP(mol) <= 6,
@@ -122,6 +152,10 @@ class ZINCDruglikeFilter(BaseFilter):
             get_num_charged_functional_groups(mol) <= 4,
             -4 <= GetFormalCharge(mol) <= 4,
         ]
+
+        if self.return_type == "condition_indicators":
+            return np.array(rules, dtype=bool)
+
         passed_rules = sum(rules)
 
         if self.allow_one_violation:

--- a/skfp/fingerprints/laggner.py
+++ b/skfp/fingerprints/laggner.py
@@ -96,7 +96,7 @@ class LaggnerFingerprint(BaseSubstructureFingerprint):
             verbose=verbose,
         )
 
-    def _fix_feature_names(self, feature_names: list[str]) -> np.array:
+    def _fix_feature_names(self, feature_names: list[str]) -> np.ndarray:
         # we modify a few names to make them all unique, since there are duplicates
         # in originals
         feature_names[16] = "Dialkylthioether (aliphatic O)"

--- a/tests/filters/beyond_ro5.py
+++ b/tests/filters/beyond_ro5.py
@@ -124,7 +124,7 @@ def test_bro5_return_indicators(
 ):
     all_smiles = smiles_passing_ro5 + smiles_failing_ro5 + smiles_beyond_ro5
 
-    filt = BeyondRo5Filter(return_indicators=True)
+    filt = BeyondRo5Filter(return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
 
     assert len(filter_indicators) == len(all_smiles)
@@ -144,7 +144,47 @@ def test_bro5_transform_x_y(smiles_passing_ro5, smiles_failing_beyond_ro5):
     assert len(mols) == len(smiles_passing_ro5)
     assert np.all(labels_filt == 1)
 
-    filt = BeyondRo5Filter(return_indicators=True)
+    filt = BeyondRo5Filter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_ro5)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_bro5_condition_names():
+    filt = BeyondRo5Filter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (6,)
+
+
+def test_bro5_return_condition_indicators(
+    smiles_passing_ro5, smiles_failing_beyond_ro5
+):
+    all_smiles = smiles_passing_ro5 + smiles_failing_beyond_ro5
+
+    filt = BeyondRo5Filter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_bro5_return_condition_indicators_transform_x_y(
+    smiles_passing_ro5, smiles_failing_beyond_ro5
+):
+    all_smiles = smiles_passing_ro5 + smiles_failing_beyond_ro5
+    labels = np.array(
+        [1] * len(smiles_passing_ro5) + [0] * len(smiles_failing_beyond_ro5)
+    )
+
+    filt = BeyondRo5Filter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/faf4_druglike.py
+++ b/tests/filters/faf4_druglike.py
@@ -104,8 +104,7 @@ def test_faf4_druglike_parallel(smiles_list):
 
 
 def test_faf4_druglike_transform_x_y(
-    smiles_passing_faf4_druglike,
-    smiles_failing_faf4_druglike,
+    smiles_passing_faf4_druglike, smiles_failing_faf4_druglike
 ):
     all_smiles = smiles_passing_faf4_druglike + smiles_failing_faf4_druglike
     labels = np.array(
@@ -133,8 +132,7 @@ def test_faf4_druglike_condition_names():
 
 
 def test_faf4_druglike_return_condition_indicators(
-    smiles_passing_faf4_druglike,
-    smiles_failing_faf4_druglike,
+    smiles_passing_faf4_druglike, smiles_failing_faf4_druglike
 ):
     all_smiles = smiles_passing_faf4_druglike + smiles_failing_faf4_druglike
 
@@ -148,8 +146,7 @@ def test_faf4_druglike_return_condition_indicators(
 
 
 def test_faf4_druglike_return_condition_indicators_transform_x_y(
-    smiles_passing_faf4_druglike,
-    smiles_failing_faf4_druglike,
+    smiles_passing_faf4_druglike, smiles_failing_faf4_druglike
 ):
     all_smiles = smiles_passing_faf4_druglike + smiles_failing_faf4_druglike
     labels = np.array(

--- a/tests/filters/faf4_druglike.py
+++ b/tests/filters/faf4_druglike.py
@@ -72,7 +72,7 @@ def test_faf4_druglike_return_indicators(
         + smiles_passing_one_violation_faf4_druglike
     )
 
-    mol_filter = FAF4DruglikeFilter(return_indicators=True)
+    mol_filter = FAF4DruglikeFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_faf4_druglike)
@@ -82,7 +82,7 @@ def test_faf4_druglike_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = FAF4DruglikeFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = FAF4DruglikeFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_faf4_druglike)
@@ -118,7 +118,50 @@ def test_faf4_druglike_transform_x_y(
     assert len(mols) == len(smiles_passing_faf4_druglike)
     assert np.all(labels_filt == 1)
 
-    filt = FAF4DruglikeFilter(return_indicators=True)
+    filt = FAF4DruglikeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_faf4_druglike)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_faf4_druglike_condition_names():
+    filt = FAF4DruglikeFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (14,)
+
+
+def test_faf4_druglike_return_condition_indicators(
+    smiles_passing_faf4_druglike,
+    smiles_failing_faf4_druglike,
+):
+    all_smiles = smiles_passing_faf4_druglike + smiles_failing_faf4_druglike
+
+    filt = FAF4DruglikeFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 14)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_faf4_druglike_return_condition_indicators_transform_x_y(
+    smiles_passing_faf4_druglike,
+    smiles_failing_faf4_druglike,
+):
+    all_smiles = smiles_passing_faf4_druglike + smiles_failing_faf4_druglike
+    labels = np.array(
+        [1] * len(smiles_passing_faf4_druglike)
+        + [0] * len(smiles_failing_faf4_druglike)
+    )
+
+    filt = FAF4DruglikeFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 14)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/faf4_leadlike.py
+++ b/tests/filters/faf4_leadlike.py
@@ -50,7 +50,7 @@ def test_faf4_leadlike_return_indicators(
 ):
     all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
 
-    mol_filter = FAF4LeadlikeFilter(return_indicators=True)
+    mol_filter = FAF4LeadlikeFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_faf4_leadlike)
@@ -95,7 +95,50 @@ def test_faf4_leadlike_transform_x_y(
     assert len(mols) == len(smiles_passing_faf4_leadlike)
     assert np.all(labels_filt == 1)
 
-    filt = FAF4LeadlikeFilter(return_indicators=True)
+    filt = FAF4LeadlikeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_faf4_leadlike)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_faf4_leadlike_condition_names():
+    filt = FAF4LeadlikeFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (15,)
+
+
+def test_faf4_leadlike_return_condition_indicators(
+    smiles_passing_faf4_leadlike,
+    smiles_failing_faf4_leadlike,
+):
+    all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
+
+    filt = FAF4LeadlikeFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 15)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_faf4_leadlike_return_condition_indicators_transform_x_y(
+    smiles_passing_faf4_leadlike,
+    smiles_failing_faf4_leadlike,
+):
+    all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
+    labels = np.array(
+        [1] * len(smiles_passing_faf4_leadlike)
+        + [0] * len(smiles_failing_faf4_leadlike)
+    )
+
+    filt = FAF4LeadlikeFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 15)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/faf4_leadlike.py
+++ b/tests/filters/faf4_leadlike.py
@@ -81,8 +81,7 @@ def test_faf4_leadlike_allow_one_violation(smiles_failing_faf4_leadlike):
 
 
 def test_faf4_leadlike_transform_x_y(
-    smiles_passing_faf4_leadlike,
-    smiles_failing_faf4_leadlike,
+    smiles_passing_faf4_leadlike, smiles_failing_faf4_leadlike
 ):
     all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
     labels = np.array(
@@ -110,8 +109,7 @@ def test_faf4_leadlike_condition_names():
 
 
 def test_faf4_leadlike_return_condition_indicators(
-    smiles_passing_faf4_leadlike,
-    smiles_failing_faf4_leadlike,
+    smiles_passing_faf4_leadlike, smiles_failing_faf4_leadlike
 ):
     all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
 
@@ -125,8 +123,7 @@ def test_faf4_leadlike_return_condition_indicators(
 
 
 def test_faf4_leadlike_return_condition_indicators_transform_x_y(
-    smiles_passing_faf4_leadlike,
-    smiles_failing_faf4_leadlike,
+    smiles_passing_faf4_leadlike, smiles_failing_faf4_leadlike
 ):
     all_smiles = smiles_passing_faf4_leadlike + smiles_failing_faf4_leadlike
     labels = np.array(

--- a/tests/filters/ghose.py
+++ b/tests/filters/ghose.py
@@ -68,7 +68,7 @@ def test_ghose_return_indicators(
         smiles_passing_ghose + smiles_failing_ghose + smiles_passing_one_violation_ghose
     )
 
-    mol_filter = GhoseFilter(return_indicators=True)
+    mol_filter = GhoseFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_ghose)
@@ -78,7 +78,7 @@ def test_ghose_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = GhoseFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = GhoseFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_ghose)
@@ -108,7 +108,43 @@ def test_ghose_transform_x_y(smiles_passing_ghose, smiles_failing_ghose):
     assert len(mols) == len(smiles_passing_ghose)
     assert np.all(labels_filt == 1)
 
-    filt = GhoseFilter(return_indicators=True)
+    filt = GhoseFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_ghose)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_ghose_condition_names():
+    filt = GhoseFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (4,)
+
+
+def test_ghose_return_condition_indicators(smiles_passing_ghose, smiles_failing_ghose):
+    all_smiles = smiles_passing_ghose + smiles_failing_ghose
+
+    filt = GhoseFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_ghose_return_condition_indicators_transform_x_y(
+    smiles_passing_ghose, smiles_failing_ghose
+):
+    all_smiles = smiles_passing_ghose + smiles_failing_ghose
+    labels = np.array([1] * len(smiles_passing_ghose) + [0] * len(smiles_failing_ghose))
+
+    filt = GhoseFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/gsk.py
+++ b/tests/filters/gsk.py
@@ -57,7 +57,7 @@ def test_gsk_return_indicators(
 ):
     all_smiles = smiles_passing_gsk + smiles_failing_gsk + smiles_passing_one_fail
 
-    mol_filter = GSKFilter(return_indicators=True)
+    mol_filter = GSKFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_gsk)
@@ -67,7 +67,7 @@ def test_gsk_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = GSKFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = GSKFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_gsk)
@@ -97,7 +97,7 @@ def test_gsk_transform_x_y(smiles_passing_gsk, smiles_failing_gsk):
     assert len(mols) == len(smiles_passing_gsk)
     assert np.all(labels_filt == 1)
 
-    filt = GSKFilter(return_indicators=True)
+    filt = GSKFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_gsk)
     assert np.array_equal(indicators, labels_filt)

--- a/tests/filters/gsk.py
+++ b/tests/filters/gsk.py
@@ -101,3 +101,39 @@ def test_gsk_transform_x_y(smiles_passing_gsk, smiles_failing_gsk):
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_gsk)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_gsk_condition_names():
+    filt = GSKFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (2,)
+
+
+def test_gsk_return_condition_indicators(smiles_passing_gsk, smiles_failing_gsk):
+    all_smiles = smiles_passing_gsk + smiles_failing_gsk
+
+    filt = GSKFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_gsk_return_condition_indicators_transform_x_y(
+    smiles_passing_gsk, smiles_failing_gsk
+):
+    all_smiles = smiles_passing_gsk + smiles_failing_gsk
+    labels = np.array([1] * len(smiles_passing_gsk) + [0] * len(smiles_failing_gsk))
+
+    filt = GSKFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/hao.py
+++ b/tests/filters/hao.py
@@ -68,7 +68,7 @@ def test_hao_return_indicators(
         smiles_passing_hao + smiles_failing_hao + smiles_passing_one_violation_hao
     )
 
-    mol_filter = HaoFilter(return_indicators=True)
+    mol_filter = HaoFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_hao)
@@ -78,7 +78,7 @@ def test_hao_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = HaoFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = HaoFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_hao)
@@ -108,7 +108,43 @@ def test_hao_transform_x_y(smiles_passing_hao, smiles_failing_hao):
     assert len(mols) == len(smiles_passing_hao)
     assert np.all(labels_filt == 1)
 
-    filt = HaoFilter(return_indicators=True)
+    filt = HaoFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_hao)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_hao_condition_names():
+    filt = HaoFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (6,)
+
+
+def test_hao_return_condition_indicators(smiles_passing_hao, smiles_failing_hao):
+    all_smiles = smiles_passing_hao + smiles_failing_hao
+
+    filt = HaoFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_hao_return_condition_indicators_transform_x_y(
+    smiles_passing_hao, smiles_failing_hao
+):
+    all_smiles = smiles_passing_hao + smiles_failing_hao
+    labels = np.array([1] * len(smiles_passing_hao) + [0] * len(smiles_failing_hao))
+
+    filt = HaoFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/lipinski.py
+++ b/tests/filters/lipinski.py
@@ -113,7 +113,7 @@ def test_lipinski_return_indicators(
         + smiles_one_lipinski_violation
     )
 
-    filt = LipinskiFilter(return_indicators=True)
+    filt = LipinskiFilter(return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_lipinski)
@@ -123,7 +123,7 @@ def test_lipinski_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    filt = LipinskiFilter(allow_one_violation=False, return_indicators=True)
+    filt = LipinskiFilter(allow_one_violation=False, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_lipinski)
@@ -145,7 +145,47 @@ def test_lipinski_transform_x_y(smiles_passing_lipinski, smiles_failing_lipinski
     assert len(mols) == len(smiles_passing_lipinski)
     assert np.all(labels_filt == 1)
 
-    filt = LipinskiFilter(return_indicators=True)
+    filt = LipinskiFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_lipinski)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_lipinski_condition_names():
+    filt = LipinskiFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (4,)
+
+
+def test_lipinski_return_condition_indicators(
+    smiles_passing_lipinski, smiles_failing_lipinski
+):
+    all_smiles = smiles_passing_lipinski + smiles_failing_lipinski
+
+    filt = LipinskiFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_lipinski_return_condition_indicators_transform_x_y(
+    smiles_passing_lipinski, smiles_failing_lipinski
+):
+    all_smiles = smiles_passing_lipinski + smiles_failing_lipinski
+    labels = np.array(
+        [1] * len(smiles_passing_lipinski) + [0] * len(smiles_failing_lipinski)
+    )
+
+    filt = LipinskiFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/mol_weight.py
+++ b/tests/filters/mol_weight.py
@@ -112,7 +112,7 @@ def test_mol_weight_return_indicators(
 ):
     all_smiles = smiles_light_mols + smiles_medium_mols + smiles_heavy_mols
 
-    filt = MolecularWeightFilter(return_indicators=True)
+    filt = MolecularWeightFilter(return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_light_mols)
@@ -122,7 +122,7 @@ def test_mol_weight_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    filt = MolecularWeightFilter(max_weight=500, return_indicators=True)
+    filt = MolecularWeightFilter(max_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_light_mols)
@@ -138,7 +138,7 @@ def test_mol_weight_min_max_thresholds(
 ):
     all_smiles = smiles_light_mols + smiles_medium_mols + smiles_heavy_mols
 
-    filt = MolecularWeightFilter(return_indicators=True)
+    filt = MolecularWeightFilter(return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_light_mols)
@@ -148,7 +148,7 @@ def test_mol_weight_min_max_thresholds(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    filt = MolecularWeightFilter(max_weight=500, return_indicators=True)
+    filt = MolecularWeightFilter(max_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_light_mols)
@@ -158,7 +158,7 @@ def test_mol_weight_min_max_thresholds(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    filt = MolecularWeightFilter(min_weight=500, return_indicators=True)
+    filt = MolecularWeightFilter(min_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
     expected_indicators = np.array(
         [False] * len(smiles_light_mols)
@@ -190,7 +190,43 @@ def test_mol_weight_transform_x_y(smiles_light_mols, smiles_heavy_mols):
     assert len(mols) == len(smiles_light_mols)
     assert np.all(labels_filt == 1)
 
-    filt = MolecularWeightFilter(return_indicators=True)
+    filt = MolecularWeightFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_light_mols)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_mol_weight_condition_names():
+    filt = MolecularWeightFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (1,)
+
+
+def test_mol_weight_return_condition_indicators(smiles_light_mols, smiles_heavy_mols):
+    all_smiles = smiles_light_mols + smiles_heavy_mols
+
+    filt = MolecularWeightFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 1)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_mol_weight_return_condition_indicators_transform_x_y(
+    smiles_light_mols, smiles_heavy_mols
+):
+    all_smiles = smiles_light_mols + smiles_heavy_mols
+    labels = np.array([1] * len(smiles_light_mols) + [0] * len(smiles_heavy_mols))
+
+    filt = MolecularWeightFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 1)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/oprea.py
+++ b/tests/filters/oprea.py
@@ -58,7 +58,7 @@ def test_oprea_filter_return_indicators(
         smiles_passing_oprea + smiles_failing_oprea + smiles_passing_oprea_one_fail
     )
 
-    mol_filter = OpreaFilter(return_indicators=True)
+    mol_filter = OpreaFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_oprea)
@@ -68,7 +68,7 @@ def test_oprea_filter_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = OpreaFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = OpreaFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_oprea)
@@ -98,7 +98,43 @@ def test_oprea_transform_x_y(smiles_passing_oprea, smiles_failing_oprea):
     assert len(mols) == len(smiles_passing_oprea)
     assert np.all(labels_filt == 1)
 
-    filt = OpreaFilter(return_indicators=True)
+    filt = OpreaFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_oprea)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_oprea_condition_names():
+    filt = OpreaFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (4,)
+
+
+def test_oprea_return_condition_indicators(smiles_passing_oprea, smiles_failing_oprea):
+    all_smiles = smiles_passing_oprea + smiles_failing_oprea
+
+    filt = OpreaFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_oprea_return_condition_indicators_transform_x_y(
+    smiles_passing_oprea, smiles_failing_oprea
+):
+    all_smiles = smiles_passing_oprea + smiles_failing_oprea
+    labels = np.array([1] * len(smiles_passing_oprea) + [0] * len(smiles_failing_oprea))
+
+    filt = OpreaFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/pfizer.py
+++ b/tests/filters/pfizer.py
@@ -70,7 +70,7 @@ def test_pfizer_return_indicators(
         + smiles_passing_one_violation_pfizer
     )
 
-    mol_filter = PfizerFilter(return_indicators=True)
+    mol_filter = PfizerFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_pfizer)
@@ -80,7 +80,7 @@ def test_pfizer_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = PfizerFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = PfizerFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_pfizer)
@@ -112,7 +112,47 @@ def test_pfizer_transform_x_y(smiles_passing_pfizer, smiles_failing_pfizer):
     assert len(mols) == len(smiles_passing_pfizer)
     assert np.all(labels_filt == 1)
 
-    filt = PfizerFilter(return_indicators=True)
+    filt = PfizerFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_pfizer)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_pfizer_condition_names():
+    filt = PfizerFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (2,)
+
+
+def test_pfizer_return_condition_indicators(
+    smiles_passing_pfizer, smiles_failing_pfizer
+):
+    all_smiles = smiles_passing_pfizer + smiles_failing_pfizer
+
+    filt = PfizerFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_pfizer_return_condition_indicators_transform_x_y(
+    smiles_passing_pfizer, smiles_failing_pfizer
+):
+    all_smiles = smiles_passing_pfizer + smiles_failing_pfizer
+    labels = np.array(
+        [1] * len(smiles_passing_pfizer) + [0] * len(smiles_failing_pfizer)
+    )
+
+    filt = PfizerFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/rule_of_four.py
+++ b/tests/filters/rule_of_four.py
@@ -70,7 +70,7 @@ def test_rule_of_four_return_indicators(
         + smiles_passing_one_violation_rule_of_four
     )
 
-    mol_filter = RuleOfFourFilter(return_indicators=True)
+    mol_filter = RuleOfFourFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_four)
@@ -80,7 +80,7 @@ def test_rule_of_four_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfFourFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfFourFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_four)
@@ -114,7 +114,47 @@ def test_rule_of_four_transform_x_y(
     assert len(mols) == len(smiles_passing_rule_of_four)
     assert np.all(labels_filt == 1)
 
-    filt = RuleOfFourFilter(return_indicators=True)
+    filt = RuleOfFourFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_rule_of_four)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_rule_of_four_condition_names():
+    filt = RuleOfFourFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (4,)
+
+
+def test_rule_of_four_return_condition_indicators(
+    smiles_passing_rule_of_four, smiles_failing_rule_of_four
+):
+    all_smiles = smiles_passing_rule_of_four + smiles_failing_rule_of_four
+
+    filt = RuleOfFourFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_rule_of_four_return_condition_indicators_transform_x_y(
+    smiles_passing_rule_of_four, smiles_failing_rule_of_four
+):
+    all_smiles = smiles_passing_rule_of_four + smiles_failing_rule_of_four
+    labels = np.array(
+        [1] * len(smiles_passing_rule_of_four) + [0] * len(smiles_failing_rule_of_four)
+    )
+
+    filt = RuleOfFourFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/rule_of_three.py
+++ b/tests/filters/rule_of_three.py
@@ -121,7 +121,7 @@ def test_rule_of_three_return_indicators(
         + smiles_passing_one_violation_extended_rule_of_three
     )
 
-    mol_filter = RuleOfThreeFilter(extended=True, return_indicators=True)
+    mol_filter = RuleOfThreeFilter(extended=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_extended_rule_of_three)
@@ -132,7 +132,7 @@ def test_rule_of_three_return_indicators(
     assert np.array_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfThreeFilter(
-        extended=True, allow_one_violation=True, return_indicators=True
+        extended=True, allow_one_violation=True, return_type="indicators"
     )
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
@@ -168,7 +168,91 @@ def test_rule_of_three_transform_x_y(
     assert len(mols) == len(smiles_passing_basic_rule_of_three)
     assert np.all(labels_filt == 1)
 
-    filt = RuleOfThreeFilter(return_indicators=True)
+    filt = RuleOfThreeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_basic_rule_of_three)
     assert np.array_equal(indicators, labels_filt)
+
+
+@pytest.mark.parametrize(
+    "filt,num_conditions",
+    [
+        (RuleOfThreeFilter(), 4),
+        (RuleOfThreeFilter(extended=True), 6),
+    ],
+)
+def test_rule_of_three_condition_names(filt, num_conditions):
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (num_conditions,)
+
+
+def test_basic_rule_of_three_return_condition_indicators(
+    smiles_passing_basic_rule_of_three, smiles_failing_basic_rule_of_three
+):
+    all_smiles = smiles_passing_basic_rule_of_three + smiles_failing_basic_rule_of_three
+
+    filt = RuleOfThreeFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_extended_rule_of_three_return_condition_indicators(
+    smiles_passing_extended_rule_of_three, smiles_failing_extended_rule_of_three
+):
+    all_smiles = (
+        smiles_passing_extended_rule_of_three + smiles_failing_extended_rule_of_three
+    )
+
+    filt = RuleOfThreeFilter(extended=True, return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_basic_rule_of_three_return_condition_indicators_transform_x_y(
+    smiles_passing_basic_rule_of_three, smiles_failing_basic_rule_of_three
+):
+    all_smiles = smiles_passing_basic_rule_of_three + smiles_failing_basic_rule_of_three
+    labels = np.array(
+        [1] * len(smiles_passing_basic_rule_of_three)
+        + [0] * len(smiles_failing_basic_rule_of_three)
+    )
+
+    filt = RuleOfThreeFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)
+
+
+def test_extended_rule_of_three_return_condition_indicators_transform_x_y(
+    smiles_passing_extended_rule_of_three, smiles_failing_extended_rule_of_three
+):
+    all_smiles = (
+        smiles_passing_extended_rule_of_three + smiles_failing_extended_rule_of_three
+    )
+    labels = np.array(
+        [1] * len(smiles_passing_extended_rule_of_three)
+        + [0] * len(smiles_failing_extended_rule_of_three)
+    )
+
+    filt = RuleOfThreeFilter(extended=True, return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/rule_of_two.py
+++ b/tests/filters/rule_of_two.py
@@ -60,7 +60,7 @@ def test_rule_of_two_return_indicators(
         + smiles_passing_one_violation_rule_of_two
     )
 
-    mol_filter = RuleOfTwoFilter(return_indicators=True)
+    mol_filter = RuleOfTwoFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_two)
@@ -70,7 +70,7 @@ def test_rule_of_two_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfTwoFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfTwoFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_two)
@@ -104,7 +104,47 @@ def test_rule_of_two_transform_x_y(
     assert len(mols) == len(smiles_passing_rule_of_two)
     assert np.all(labels_filt == 1)
 
-    filt = RuleOfTwoFilter(return_indicators=True)
+    filt = RuleOfTwoFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_rule_of_two)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_rule_of_two_condition_names():
+    filt = RuleOfTwoFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (4,)
+
+
+def test_rule_of_two_return_condition_indicators(
+    smiles_passing_rule_of_two, smiles_failing_rule_of_two
+):
+    all_smiles = smiles_passing_rule_of_two + smiles_failing_rule_of_two
+
+    filt = RuleOfTwoFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_rule_of_two_return_condition_indicators_transform_x_y(
+    smiles_passing_rule_of_two, smiles_failing_rule_of_two
+):
+    all_smiles = smiles_passing_rule_of_two + smiles_failing_rule_of_two
+    labels = np.array(
+        [1] * len(smiles_passing_rule_of_two) + [0] * len(smiles_failing_rule_of_two)
+    )
+
+    filt = RuleOfTwoFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/rule_of_veber.py
+++ b/tests/filters/rule_of_veber.py
@@ -57,7 +57,7 @@ def test_rule_of_veber_return_indicators(
         + smiles_passing_one_fail
     )
 
-    mol_filter = RuleOfVeberFilter(return_indicators=True)
+    mol_filter = RuleOfVeberFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_veber)
@@ -67,7 +67,7 @@ def test_rule_of_veber_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfVeberFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfVeberFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_veber)
@@ -102,7 +102,48 @@ def test_rule_of_veber_transform_x_y(
     assert len(mols) == len(smiles_passing_rule_of_veber)
     assert np.all(labels_filt == 1)
 
-    filt = RuleOfVeberFilter(return_indicators=True)
+    filt = RuleOfVeberFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_rule_of_veber)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_rule_of_veber_condition_names():
+    filt = RuleOfVeberFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (2,)
+
+
+def test_rule_of_veber_return_condition_indicators(
+    smiles_passing_rule_of_veber, smiles_failing_rule_of_veber
+):
+    all_smiles = smiles_passing_rule_of_veber + smiles_failing_rule_of_veber
+
+    filt = RuleOfVeberFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_rule_of_veber_return_condition_indicators_transform_x_y(
+    smiles_passing_rule_of_veber, smiles_failing_rule_of_veber
+):
+    all_smiles = smiles_passing_rule_of_veber + smiles_failing_rule_of_veber
+    labels = np.array(
+        [1] * len(smiles_passing_rule_of_veber)
+        + [0] * len(smiles_failing_rule_of_veber)
+    )
+
+    filt = RuleOfVeberFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/rule_of_xu.py
+++ b/tests/filters/rule_of_xu.py
@@ -59,7 +59,7 @@ def test_rule_of_xu_return_indicators(
         smiles_passing_rule_of_xu + smiles_failing_rule_of_xu + smiles_passing_one_fail
     )
 
-    mol_filter = RuleOfXuFilter(return_indicators=True)
+    mol_filter = RuleOfXuFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_xu)
@@ -69,7 +69,7 @@ def test_rule_of_xu_return_indicators(
     )
     assert np.array_equal(filter_indicators, expected_indicators)
 
-    mol_filter = RuleOfXuFilter(allow_one_violation=True, return_indicators=True)
+    mol_filter = RuleOfXuFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_rule_of_xu)
@@ -101,7 +101,47 @@ def test_rule_of_xu_transform_x_y(smiles_passing_rule_of_xu, smiles_failing_rule
     assert len(mols) == len(smiles_passing_rule_of_xu)
     assert np.all(labels_filt == 1)
 
-    filt = RuleOfXuFilter(return_indicators=True)
+    filt = RuleOfXuFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_rule_of_xu)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_rule_of_xu_condition_names():
+    filt = RuleOfXuFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (5,)
+
+
+def test_rule_of_xu_return_condition_indicators(
+    smiles_passing_rule_of_xu, smiles_failing_rule_of_xu
+):
+    all_smiles = smiles_passing_rule_of_xu + smiles_failing_rule_of_xu
+
+    filt = RuleOfXuFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_rule_of_xu_return_condition_indicators_transform_x_y(
+    smiles_passing_rule_of_xu, smiles_failing_rule_of_xu
+):
+    all_smiles = smiles_passing_rule_of_xu + smiles_failing_rule_of_xu
+    labels = np.array(
+        [1] * len(smiles_passing_rule_of_xu) + [0] * len(smiles_failing_rule_of_xu)
+    )
+
+    filt = RuleOfXuFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/valence_discovery.py
+++ b/tests/filters/valence_discovery.py
@@ -74,7 +74,7 @@ def test_valence_discovery_return_indicators(
         + smiles_passing_one_violation_valence_discovery
     )
 
-    mol_filter = ValenceDiscoveryFilter(return_indicators=True)
+    mol_filter = ValenceDiscoveryFilter(return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
         [True] * len(smiles_passing_valence_discovery)
@@ -85,7 +85,7 @@ def test_valence_discovery_return_indicators(
     assert np.array_equal(filter_indicators, expected_indicators)
 
     mol_filter = ValenceDiscoveryFilter(
-        allow_one_violation=True, return_indicators=True
+        allow_one_violation=True, return_type="indicators"
     )
     filter_indicators = mol_filter.transform(all_smiles)
     expected_indicators = np.array(
@@ -121,7 +121,48 @@ def test_valence_discovery_transform_x_y(
     assert len(mols) == len(smiles_passing_valence_discovery)
     assert np.all(labels_filt == 1)
 
-    filt = ValenceDiscoveryFilter(return_indicators=True)
+    filt = ValenceDiscoveryFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
     assert np.sum(indicators) == len(smiles_passing_valence_discovery)
     assert np.array_equal(indicators, labels_filt)
+
+
+def test_valence_discovery_condition_names():
+    filt = ValenceDiscoveryFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (16,)
+
+
+def test_valence_discovery_return_condition_indicators(
+    smiles_passing_valence_discovery, smiles_failing_valence_discovery
+):
+    all_smiles = smiles_passing_valence_discovery + smiles_failing_valence_discovery
+
+    filt = ValenceDiscoveryFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(all_smiles)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 16)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_valence_discovery_return_condition_indicators_transform_x_y(
+    smiles_passing_valence_discovery, smiles_failing_valence_discovery
+):
+    all_smiles = smiles_passing_valence_discovery + smiles_failing_valence_discovery
+    labels = np.array(
+        [1] * len(smiles_passing_valence_discovery)
+        + [0] * len(smiles_failing_valence_discovery)
+    )
+
+    filt = ValenceDiscoveryFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(all_smiles, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(all_smiles), 16)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)

--- a/tests/filters/zinc_druglike.py
+++ b/tests/filters/zinc_druglike.py
@@ -38,3 +38,34 @@ def test_zinc_druglike_transform_x_y(mols_list):
     filt = ZINCDruglikeFilter()
     mols_filtered, labels_filt = filt.transform_x_y(mols_list, labels)
     assert len(mols_filtered) == len(labels_filt)
+
+
+def test_zinc_druglike_condition_names():
+    filt = ZINCDruglikeFilter()
+    condition_names = filt.get_feature_names_out()
+
+    assert isinstance(condition_names, np.ndarray)
+    assert condition_names.shape == (13,)
+
+
+def test_zinc_druglike_return_condition_indicators(mols_list):
+    filt = ZINCDruglikeFilter(return_type="condition_indicators")
+    condition_indicators = filt.transform(mols_list)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(mols_list), 13)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+
+
+def test_zinc_druglike_return_condition_indicators_transform_x_y(mols_list):
+    labels = np.ones(len(mols_list))
+
+    filt = ZINCDruglikeFilter(return_type="condition_indicators")
+    condition_indicators, y = filt.transform_x_y(mols_list, labels)
+
+    assert isinstance(condition_indicators, np.ndarray)
+    assert condition_indicators.shape == (len(mols_list), 13)
+    assert np.issubdtype(condition_indicators.dtype, bool)
+    assert np.all(np.isin(condition_indicators, [0, 1]))
+    assert len(condition_indicators) == len(y)


### PR DESCRIPTION
## Changes

Added condition names for physicochemical properties filters, implementing about half of https://github.com/scikit-fingerprints/scikit-fingerprints/issues/459. This PR also deprecates the `return_indicators` and introduces `return_type` for filters.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
