### PR TITLE
Add ResponseVariableRange and StdEnsemble AD checkers with tests

### DIFF
--- a/docs/modules/applicability_domain.rst
+++ b/docs/modules/applicability_domain.rst
@@ -20,3 +20,5 @@ Classes for checking applicability domain.
     HotellingT2TestADChecker
     LeverageADChecker
     PCABoundingBoxADChecker
+    ResponseVariableRangeADChecker
+    StdEnsembleADChecker

--- a/skfp/applicability_domain/__init__.py
+++ b/skfp/applicability_domain/__init__.py
@@ -4,3 +4,5 @@ from .distance_to_centroid import DistanceToCentroidADChecker
 from .hotelling_t2_test import HotellingT2TestADChecker
 from .leverage import LeverageADChecker
 from .pca_bounding_box import PCABoundingBoxADChecker
+from .response_variable_range import ResponseVariableRangeADChecker
+from .standard_deviation import StdEnsembleADChecker

--- a/skfp/applicability_domain/bounding_box.py
+++ b/skfp/applicability_domain/bounding_box.py
@@ -13,7 +13,7 @@ class BoundingBoxADChecker(BaseADChecker):
 
     Defines applicability domain based on feature ranges in the training data.
     This creates a "bounding box" using their extreme values, and new molecules
-    should lie in this distribution, i.e. have properties in the same ranges.
+    should lie in this distribution, i.e. have properties in the same ranges [1]_.
 
     Typically, physicochemical properties (continous features) are used as inputs.
     Consider scaling, normalizing, or transforming them before computing AD to lessen
@@ -56,6 +56,15 @@ class BoundingBoxADChecker(BaseADChecker):
         Controls the verbosity when filtering molecules.
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
+
+    References
+    ----------
+    .. [1] `Kar, S., Roy, K., Leszczynski, J.
+        "Applicability Domain: A Step Toward Confident Predictions and Decidability
+        for QSAR Modeling."
+        Nicolotti, O. (eds) Computational Toxicology. Methods in Molecular Biology, vol 1800.
+        Humana Press, New York, NY
+        <https://doi.org/10.1007/978-1-4939-7899-1_6>`_
 
     Examples
     --------

--- a/skfp/applicability_domain/response_variable_range.py
+++ b/skfp/applicability_domain/response_variable_range.py
@@ -1,0 +1,98 @@
+import numpy as np
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from skfp.bases.base_ad_checker import BaseADChecker
+
+
+class ResponseVariableRangeADChecker(BaseADChecker):
+    """
+    Response variable range method.
+
+    Defines applicability domain based on the range of response values observed
+    in the training data. New predictions are considered inside the applicability
+    domain if they lie within the min-max range of training targets.
+
+    Typically, this method is used after model prediction, and checks whether
+    predicted values lie within the known domain of the response variable.
+
+    Note that this method does not consider molecular structure or descriptors.
+    It operates purely in the output (target) space.
+
+    This method scales extremely well with both number of samples and features.
+
+    Parameters
+    ----------
+    n_jobs : int, default=None
+        The number of jobs to run in parallel. :meth:`transform_x_y` and
+        :meth:`transform` are parallelized over the input molecules. ``None`` means 1
+        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See scikit-learn documentation on ``n_jobs`` for more details.
+
+    verbose : int or dict, default=0
+        Controls the verbosity when filtering molecules.
+        If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
+        and can be used to control the progress bar.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skfp.applicability_domain import ResponseVariableRangeADChecker
+    >>> y_train = np.array([0.5, 1.2, 1.5, 0.9])
+    >>> y_pred = np.array([1.0, 1.6, 0.4])
+    >>> response_range_ad_checker = ResponseVariableRangeADChecker()
+    >>> response_range_ad_checker
+    ResponseVariableRangeADChecker()
+
+    >>> response_range_ad_checker.fit(y_train)
+    ResponseVariableRangeADChecker()
+
+    >>> response_range_ad_checker.predict(y_pred)
+    array([ True, False, False])
+    """
+
+    def __init__(
+        self,
+        n_jobs: int | None = None,
+        verbose: int | dict = 0,
+    ):
+        super().__init__(
+            n_jobs=n_jobs,
+            verbose=verbose,
+        )
+
+    def fit(  # noqa: D102
+        self,
+        X: np.ndarray,
+        y: np.ndarray | None = None,
+    ):
+        y = validate_data(self, X=X, ensure_2d=False)
+        self.min_y_ = np.min(y)
+        self.max_y_ = np.max(y)
+        self.mean_y_ = np.mean(y)
+        return self
+
+    def predict(self, y: np.ndarray) -> np.ndarray:  # noqa: D102
+        check_is_fitted(self)
+        y = validate_data(self, X=y, ensure_2d=False, reset=False)
+        return (self.min_y_ <= y) & (self.max_y_ >= y)
+
+    def score_samples(self, y: np.ndarray) -> np.ndarray:
+        """
+        Calculate the applicability domain score of samples. It is defined as
+        the absolute distance of each predicted value from the training response mean.
+        Lower scores indicate that a prediction is closer to the center of the training
+        response distribution.
+
+        Parameters
+        ----------
+        y : array-like of shape (n_samples,)
+            Predicted response values.
+
+        Returns
+        -------
+        scores : ndarray of shape (n_samples,)
+            Applicability domain scores of samples.
+
+        """
+        y = validate_data(self, X=y, ensure_2d=False, reset=False)
+        return np.abs(y - self.mean_y_)

--- a/skfp/applicability_domain/response_variable_range.py
+++ b/skfp/applicability_domain/response_variable_range.py
@@ -9,7 +9,7 @@ class ResponseVariableRangeADChecker(BaseADChecker):
     Response variable range method.
 
     Defines applicability domain based on the range of response values observed
-    in the training data. New predictions are considered inside the applicability
+    in the training data [1]_. New predictions are considered inside the applicability
     domain if they lie within the min-max range of training targets.
 
     Typically, this method is used after model prediction, and checks whether
@@ -18,7 +18,8 @@ class ResponseVariableRangeADChecker(BaseADChecker):
     Note that this method does not consider molecular structure or descriptors.
     It operates purely in the output (target) space.
 
-    This method scales extremely well with both number of samples and features.
+    This method scales extremely well with the number of samples,
+    as it only operates in the 1D target space.
 
     Parameters
     ----------
@@ -32,6 +33,15 @@ class ResponseVariableRangeADChecker(BaseADChecker):
         Controls the verbosity when filtering molecules.
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
+
+    References
+    ----------
+    .. [1] `Kar, S., Roy, K., Leszczynski, J.
+        "Applicability Domain: A Step Toward Confident Predictions and Decidability
+        for QSAR Modeling."
+        Nicolotti, O. (eds) Computational Toxicology. Methods in Molecular Biology, vol 1800.
+        Humana Press, New York, NY
+        <https://doi.org/10.1007/978-1-4939-7899-1_6>`_
 
     Examples
     --------
@@ -60,12 +70,12 @@ class ResponseVariableRangeADChecker(BaseADChecker):
             verbose=verbose,
         )
 
-    def fit(  # noqa: D102
+    def fit(  # type: ignore[override]  # noqa: D102
         self,
-        X: np.ndarray,
-        y: np.ndarray | None = None,
+        y: np.ndarray,
+        X: np.ndarray | None = None,  # noqa: ARG002
     ):
-        y = validate_data(self, X=X, ensure_2d=False)
+        y = validate_data(self, X=y, ensure_2d=False)
         self.min_y_ = np.min(y)
         self.max_y_ = np.max(y)
         self.mean_y_ = np.mean(y)

--- a/skfp/applicability_domain/standard_deviation.py
+++ b/skfp/applicability_domain/standard_deviation.py
@@ -1,0 +1,119 @@
+import numpy as np
+from sklearn.utils.validation import validate_data
+
+from skfp.bases.base_ad_checker import BaseADChecker
+
+
+class StdEnsembleADChecker(BaseADChecker):
+    """
+    Standard deviation ensemble method.
+
+    Defines applicability domain based on the spread (standard deviation) of predictions
+    from individual estimators in an ensemble model. The method assumes that
+    if different estimators give similar predictions for a given molecule,
+    the prediction is more likely to be reliable (i.e., in-domain).
+
+    This approach requires an ensemble model exposing the ``estimators_``
+    attribute (e.g., RandomForestRegressor), where each
+    sub-model must implement a ``predict(X)`` method. At prediction time,
+    each sample is passed to all estimators, and the standard deviation of
+    their predictions is calculated. The sample is considered in-domain if
+    the standard deviation is lower than or equal to the specified threshold.
+
+    Typically, physicochemical properties (continous features) are used as inputs.
+    Consider scaling, normalizing, or transforming them before computing AD to lessen
+    effects of outliers, e.g. with ``PowerTransformer`` or ``RobustScaler``.
+
+    This method is particularly useful in assessing uncertainty in ensemble
+    learning-based QSAR models.
+
+    Parameters
+    ----------
+    model : object
+        Fitted ensemble model with accessible ``estimators_`` attribute and
+        ``predict(X)`` method on each sub-estimator.
+
+    threshold : float, default=1.0
+        Maximum allowed standard deviation of predictions. Samples with
+        higher spread will be considered outside the applicability domain.
+
+    n_jobs : int, default=None
+        The number of jobs to run in parallel. :meth:`transform_x_y` and
+        :meth:`transform` are parallelized over the input molecules. ``None`` means 1
+        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See scikit-learn documentation on ``n_jobs`` for more details.
+
+    verbose : int or dict, default=0
+        Controls the verbosity when filtering molecules.
+        If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
+        and can be used to control the progress bar.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.ensemble import RandomForestRegressor
+    >>> from skfp.applicability_domain import StdEnsembleADChecker
+    >>> X_train = np.random.uniform(0, 1, size=(1000, 5))
+    >>> y_train = X_train.sum(axis=1)
+    >>> model = RandomForestRegressor(n_estimators=5, random_state=0)
+    >>> model.fit(X_train, y_train)
+    >>> std_ad_checker = StdEnsembleADChecker(model=model, threshold=0.5)
+    >>> std_ad_checker
+    StdEnsembleADChecker()
+
+    >>> X_test = np.random.uniform(0, 1, size=(100, 5))
+    >>> std_ad_checker.predict(X_test).shape
+    (100,)
+    """
+
+    def __init__(
+        self,
+        model,
+        threshold: float = 1.0,
+        n_jobs: int | None = None,
+        verbose: int | dict = 0,
+    ):
+        super().__init__(
+            n_jobs=n_jobs,
+            verbose=verbose,
+        )
+        self.model = model
+        self.threshold = threshold
+
+    def fit(  # noqa: D102
+        self,
+        X: np.ndarray,
+        y: np.ndarray | None = None,
+    ):
+        pass  # unused
+
+    def _predict_all_estimators(self, X: np.ndarray) -> np.ndarray:
+        preds = np.array([est.predict(X) for est in self.model.estimators_])
+        return preds.T
+
+    def predict(self, X: np.ndarray) -> np.ndarray:  # noqa: D102
+        X = validate_data(self, X=X, reset=False)
+
+        preds = self._predict_all_estimators(X)
+        stds = np.std(preds, axis=1)
+
+        return (stds <= self.threshold).astype(bool)
+
+    def score_samples(self, X: np.ndarray) -> np.ndarray:
+        """
+        Calculate the applicability domain score of samples.
+        It is defined as the standard deviation of ensemble predictions.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data matrix.
+
+        Returns
+        -------
+        scores : ndarray of shape (n_samples,)
+             Standard deviations of predictions.
+        """
+        X = validate_data(self, X=X, reset=False)
+        preds = self._predict_all_estimators(X)
+        return np.std(preds, axis=1)

--- a/skfp/applicability_domain/standard_deviation.py
+++ b/skfp/applicability_domain/standard_deviation.py
@@ -1,4 +1,7 @@
+from numbers import Real
+
 import numpy as np
+from sklearn.utils._param_validation import Interval
 from sklearn.utils.validation import validate_data
 
 from skfp.bases.base_ad_checker import BaseADChecker
@@ -9,7 +12,7 @@ class StdEnsembleADChecker(BaseADChecker):
     Standard deviation ensemble method.
 
     Defines applicability domain based on the spread (standard deviation) of predictions
-    from individual estimators in an ensemble model. The method assumes that
+    from individual estimators in an ensemble model [1]_. The method assumes that
     if different estimators give similar predictions for a given molecule,
     the prediction is more likely to be reliable (i.e., in-domain).
 
@@ -48,6 +51,15 @@ class StdEnsembleADChecker(BaseADChecker):
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
 
+    References
+    ----------
+    .. [1] `Kar, S., Roy, K., Leszczynski, J.
+        "Applicability Domain: A Step Toward Confident Predictions and Decidability
+        for QSAR Modeling."
+        Nicolotti, O. (eds) Computational Toxicology. Methods in Molecular Biology, vol 1800.
+        Humana Press, New York, NY
+        <https://doi.org/10.1007/978-1-4939-7899-1_6>`_
+
     Examples
     --------
     >>> import numpy as np
@@ -66,6 +78,12 @@ class StdEnsembleADChecker(BaseADChecker):
     (100,)
     """
 
+    _parameter_constraints: dict = {
+        **BaseADChecker._parameter_constraints,
+        "model": [object],
+        "threshold": [Interval(Real, 0, None, closed="left")],
+    }
+
     def __init__(
         self,
         model,
@@ -82,10 +100,10 @@ class StdEnsembleADChecker(BaseADChecker):
 
     def fit(  # noqa: D102
         self,
-        X: np.ndarray,
-        y: np.ndarray | None = None,
+        X: np.ndarray,  # noqa: ARG002
+        y: np.ndarray | None = None,  # noqa: ARG002
     ):
-        pass  # unused
+        return self
 
     def _predict_all_estimators(self, X: np.ndarray) -> np.ndarray:
         preds = np.array([est.predict(X) for est in self.model.estimators_])

--- a/tests/applicability_domain/response_variable_range.py
+++ b/tests/applicability_domain/response_variable_range.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from skfp.applicability_domain import ResponseVariableRangeADChecker
+from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
+
+
+def test_inside_response_range_ad():
+    y_train, y_test = get_data_inside_ad()
+    y_train = y_train[:, 0]
+    y_test = y_test[:, 0]
+
+    ad_checker = ResponseVariableRangeADChecker()
+    ad_checker.fit(y_train)
+
+    scores = ad_checker.score_samples(y_test)
+    assert np.all(scores >= 0)
+
+    preds = ad_checker.predict(y_test)
+    assert isinstance(preds, np.ndarray)
+    assert np.isdtype(preds.dtype, np.bool)
+    assert preds.shape == (len(y_test),)
+    assert np.all(preds == 1)
+
+
+def test_outside_response_range_ad():
+    y_train, y_test = get_data_outside_ad()
+    y_train = y_train[:, 0]
+    y_test = y_test[:, 0]
+
+    ad_checker = ResponseVariableRangeADChecker()
+    ad_checker.fit(y_train)
+
+    scores = ad_checker.score_samples(y_test)
+    assert np.all(scores >= 0)
+
+    preds = ad_checker.predict(y_test)
+    assert isinstance(preds, np.ndarray)
+    assert np.isdtype(preds.dtype, np.bool)
+    assert preds.shape == (len(y_test),)
+    assert np.all(preds == 0)
+
+
+def test_response_range_pass_y_train():
+    # smoke test, should not throw errors
+    X_train = np.vstack((np.zeros((10, 5)), np.ones((10, 5))))
+    y_train = np.zeros(10)
+    ad_checker = ResponseVariableRangeADChecker()
+    ad_checker.fit(X_train, y_train)

--- a/tests/applicability_domain/standard_deviation.py
+++ b/tests/applicability_domain/standard_deviation.py
@@ -1,0 +1,60 @@
+import numpy as np
+from sklearn.datasets import make_regression
+from sklearn.ensemble import RandomForestRegressor
+
+from skfp.applicability_domain import StdEnsembleADChecker
+
+
+def test_inside_std_ad():
+    X_train, y_train = make_regression(
+        n_samples=1000, n_features=2, noise=0.1, random_state=42
+    )
+    X_test = X_train[:100]
+
+    rf = RandomForestRegressor(n_estimators=5, random_state=42)
+    rf.fit(X_train, y_train)
+
+    ad_checker = StdEnsembleADChecker(model=rf, threshold=10.0)
+
+    scores = ad_checker.score_samples(X_test)
+    assert np.all(scores >= 0)
+
+    preds = ad_checker.predict(X_test)
+    assert isinstance(preds, np.ndarray)
+    assert np.isdtype(preds.dtype, np.bool)
+    assert preds.shape == (len(X_test),)
+    assert np.all(preds == 1)
+
+
+def test_outside_std_ad():
+    X_train, y_train = make_regression(
+        n_samples=1000, n_features=2, noise=0.1, random_state=42
+    )
+    X_test = X_train[:100] * 100
+
+    rf = RandomForestRegressor(n_estimators=5, random_state=42)
+    rf.fit(X_train, y_train)
+
+    ad_checker = StdEnsembleADChecker(model=rf, threshold=1.0)
+
+    scores = ad_checker.score_samples(X_test)
+    assert np.all(scores >= 0)
+
+    preds = ad_checker.predict(X_test)
+    assert isinstance(preds, np.ndarray)
+    assert np.isdtype(preds.dtype, np.bool)
+    assert preds.shape == (len(X_test),)
+    assert np.all(preds == 0)
+
+
+def test_std_fit():
+    # smoke test, should not throw errors
+    X_train, y_train = make_regression(
+        n_samples=100, n_features=2, noise=0.1, random_state=42
+    )
+
+    rf = RandomForestRegressor(n_estimators=5, random_state=42)
+    rf.fit(X_train, y_train)
+
+    ad_checker = StdEnsembleADChecker(model=rf)
+    ad_checker.fit(X_train, y_train)


### PR DESCRIPTION
## Changes

Added `ResponseVariableRange` and `StdEnsemble` applicability domain (AD) checkers, and provided tests.
Also, added missing references to the documentation of the `BoundingBoxADChecker`. Part of  https://github.com/scikit-fingerprints/scikit-fingerprints/issues/424

## Checklist before requesting a review
- [ ] Docstrings added/updated in public functions and classes
- [ ] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
