### PR TITLE
Add missing TDC imports

### DIFF
--- a/skfp/datasets/tdc/__init__.py
+++ b/skfp/datasets/tdc/__init__.py
@@ -1,1 +1,40 @@
-from .benchmark import load_tdc_benchmark, load_tdc_splits
+from .adme import (
+    load_b3db_classification,
+    load_b3db_regression,
+    load_bioavailability_ma,
+    load_caco2_wang,
+    load_clearance_hepatocyte_az,
+    load_clearance_microsome_az,
+    load_cyp1a2_veith,
+    load_cyp2c9_substrate_carbonmangels,
+    load_cyp2c9_veith,
+    load_cyp2c19_veith,
+    load_cyp2d6_substrate_carbonmangels,
+    load_cyp2d6_veith,
+    load_cyp3a4_substrate_carbonmangels,
+    load_cyp3a4_veith,
+    load_half_life_obach,
+    load_hia_hou,
+    load_hlm,
+    load_pampa_approved_drugs,
+    load_pampa_ncats,
+    load_pgp_broccatelli,
+    load_ppbr_az,
+    load_rlm,
+    load_solubility_aqsoldb,
+    load_vdss_lombardo,
+)
+from .benchmark import load_tdc_benchmark, load_tdc_dataset, load_tdc_splits
+from .hts import load_sarscov2_3clpro_diamond, load_sarscov2_vitro_touret
+from .tox import (
+    load_ames,
+    load_carcinogens_lagunin,
+    load_dili,
+    load_herg,
+    load_herg_central_at_1um,
+    load_herg_central_at_10um,
+    load_herg_central_inhib,
+    load_herg_karim,
+    load_ld50_zhu,
+    load_skin_reaction,
+)


### PR DESCRIPTION
## Changes

I noticed that dataset loading functions were missing from TDC, in contrast to MoleculeNet and LRGB. This PR adds them to unify this.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
