### PR TITLE
Fix a small typo

### DIFF
--- a/skfp/fingerprints/rdkit_2d_desc.py
+++ b/skfp/fingerprints/rdkit_2d_desc.py
@@ -17,7 +17,7 @@ class RDKit2DDescriptorsFingerprint(BaseFingerprintTransformer):
     The implementation uses descriptastorus [1]_ and RDKit. This fingerprint consists
     of 200 2D descriptors available in RDKit (almost all). List of all features is
     available in descriptastorus code and in the supplementary material of the original
-    paper[2]_.
+    paper [2]_.
 
     Normalized variant uses cumulative distribution function (CDF) normalization, as
     proposed in [2]_. Distributions for normalization have been determined using a


### PR DESCRIPTION
## Changes

Fixed a small typo in reference in RDKit 2D descriptors fingerprint.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
