### PR TITLE
Small fix for filters

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -257,6 +257,7 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
                 filter_indicators = [
                     self._filter_mols_batch([mol]) for mol in tqdm(mols)
                 ]
+                filter_indicators = np.array(filter_indicators).ravel()
             else:
                 filter_indicators = self._filter_mols_batch(mols)
         else:


### PR DESCRIPTION
## Changes

Small fix for situations where in filters we have `n_jobs=1` and `verbose=True`. Filter indicators were not flattened properly, which resulted in indexing error.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
