### PR TITLE
MACCS fingerprint fix

### DIFF
--- a/skfp/fingerprints/maccs.py
+++ b/skfp/fingerprints/maccs.py
@@ -494,7 +494,7 @@ class MACCSFingerprint(BaseFingerprintTransformer):
             X = [self._get_maccs_patterns_counts(mol) for mol in X]
         else:
             X = [GetMACCSKeysFingerprint(mol) for mol in X]
-            X = np.array(X)[:, 1:]  # remove constant zeros column
+            X = np.vstack(X)[:, 1:]  # remove constant zeros column
 
         dtype = np.uint32 if self.count else np.uint8
         return csr_array(X, dtype=dtype) if self.sparse else np.array(X, dtype=dtype)


### PR DESCRIPTION
## Changes

With latest RDKit, I was getting segfault error with MACCS -> NumPy conversion. For some reason `np.array()` errors, but `np.vstack()` works without problems.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
