### PR TITLE
Small docs fix for OGB function

### DIFF
--- a/skfp/datasets/moleculenet/benchmark.py
+++ b/skfp/datasets/moleculenet/benchmark.py
@@ -97,8 +97,7 @@ def load_moleculenet_benchmark(
 
     Parameters
     ----------
-    subset : {None, "regression", "classification", "classification_single_task",
-              "classification_multitask", "classification_no_pcba"} or list of strings
+    subset : {None, "regression", "classification", "classification_single_task", "classification_multitask", "classification_no_pcba"} or list of strings
         If ``None``, returns all datasets. String loads only a given subset of all
         datasets. List of strings loads only datasets with given names.
 
@@ -180,8 +179,7 @@ def load_moleculenet_dataset(
 
     Parameters
     ----------
-    dataset_name : {"ESOL", "FreeSolv", "Lipophilicity","BACE", "BBBP", "HIV", "ClinTox",
-        "MUV", "SIDER", "Tox21", "ToxCast", "PCBA"}
+    dataset_name : {"ESOL", "FreeSolv", "Lipophilicity","BACE", "BBBP", "HIV", "ClinTox", "MUV", "SIDER", "Tox21", "ToxCast", "PCBA"}
         Name of the dataset to load.
 
     data_dir : {None, str, path-like}, default=None
@@ -258,8 +256,7 @@ def load_ogb_splits(
 
     Parameters
     ----------
-    dataset_name : {"ESOL", "FreeSolv", "Lipophilicity","BACE", "BBBP", "HIV", "ClinTox",
-        "MUV", "SIDER", "Tox21", "ToxCast", "PCBA"}
+    dataset_name : {"ESOL", "FreeSolv", "Lipophilicity","BACE", "BBBP", "HIV", "ClinTox", "MUV", "SIDER", "Tox21", "ToxCast", "PCBA"}
         Name of the dataset to loads splits for.
 
     data_dir : {None, str, path-like}, default=None


### PR DESCRIPTION
## Changes

I noticed that parameters weren't rendering nicely in OGB splits function. It turns out that all parameter values in the docstring need to be in the same line.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
