### PR TITLE
Refactor tests for better error messages

### DIFF
--- a/tests/applicability_domain/bounding_box.py
+++ b/tests/applicability_domain/bounding_box.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import BoundingBoxADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -16,7 +17,7 @@ def test_inside_bounding_box_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -32,7 +33,7 @@ def test_outside_bounding_box_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/applicability_domain/convex_hull.py
+++ b/tests/applicability_domain/convex_hull.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import ConvexHullADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -16,7 +17,7 @@ def test_inside_convex_hull_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -32,7 +33,7 @@ def test_outside_convex_hull_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/applicability_domain/distance_to_centroid.py
+++ b/tests/applicability_domain/distance_to_centroid.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import DistanceToCentroidADChecker
 from skfp.applicability_domain.distance_to_centroid import SCIPY_METRIC_NAMES
@@ -27,7 +28,7 @@ def test_inside_distance_to_centroid_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -43,7 +44,7 @@ def test_outside_distance_to_centroid_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/applicability_domain/hotelling_t2_test.py
+++ b/tests/applicability_domain/hotelling_t2_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import HotellingT2TestADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -17,7 +18,7 @@ def test_inside_hotelling_t2_test_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -33,7 +34,7 @@ def test_outside_hotelling_t2_test_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 
@@ -51,7 +52,7 @@ def test_hotelling_t2_test_options(alpha):
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 

--- a/tests/applicability_domain/knn.py
+++ b/tests/applicability_domain/knn.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import KNNADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -9,11 +10,11 @@ ALLOWED_METRICS = [
     "tanimoto_count_distance",
 ]
 
-ALLOWED_AGGS = ["mean", "max", "min"]
+ALLOWED_AGGREGATIONS = ["mean", "max", "min"]
 
 
 @pytest.mark.parametrize("metric", ALLOWED_METRICS)
-@pytest.mark.parametrize("agg", ALLOWED_AGGS)
+@pytest.mark.parametrize("agg", ALLOWED_AGGREGATIONS)
 def test_inside_knn_ad(metric, agg):
     if "binary" in metric:
         X_train, X_test = get_data_inside_ad(binarize=True)
@@ -24,17 +25,18 @@ def test_inside_knn_ad(metric, agg):
     ad_checker.fit(X_train)
 
     scores = ad_checker.score_samples(X_test)
+    assert_equal(scores.shape, (len(X_test),))
     assert scores.shape == (len(X_test),)
 
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.issubdtype(preds.dtype, np.bool_)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
 @pytest.mark.parametrize("metric", ALLOWED_METRICS)
-@pytest.mark.parametrize("agg", ALLOWED_AGGS)
+@pytest.mark.parametrize("agg", ALLOWED_AGGREGATIONS)
 def test_outside_knn_ad(metric, agg):
     if "binary" in metric:
         X_train, X_test = get_data_outside_ad(binarize=True)
@@ -48,15 +50,14 @@ def test_outside_knn_ad(metric, agg):
     assert np.all(scores >= 0)
 
     preds = ad_checker.predict(X_test)
-    print(preds)
     assert isinstance(preds, np.ndarray)
     assert np.issubdtype(preds.dtype, np.bool_)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 
 @pytest.mark.parametrize("metric", ALLOWED_METRICS)
-@pytest.mark.parametrize("agg", ALLOWED_AGGS)
+@pytest.mark.parametrize("agg", ALLOWED_AGGREGATIONS)
 def test_knn_different_k_values(metric, agg):
     if "binary" in metric:
         X_train, X_test = get_data_inside_ad(binarize=True)
@@ -79,7 +80,7 @@ def test_knn_different_k_values(metric, agg):
 
 
 @pytest.mark.parametrize("metric", ALLOWED_METRICS)
-@pytest.mark.parametrize("agg", ALLOWED_AGGS)
+@pytest.mark.parametrize("agg", ALLOWED_AGGREGATIONS)
 def test_knn_pass_y_train(metric, agg):
     # smoke test, should not throw errors
     if "binary" in metric:
@@ -93,7 +94,7 @@ def test_knn_pass_y_train(metric, agg):
 
 
 @pytest.mark.parametrize("metric", ALLOWED_METRICS)
-@pytest.mark.parametrize("agg", ALLOWED_AGGS)
+@pytest.mark.parametrize("agg", ALLOWED_AGGREGATIONS)
 def test_knn_invalid_k(metric, agg):
     if "binary" in metric:
         X_train, _ = get_data_inside_ad(binarize=True)

--- a/tests/applicability_domain/leverage.py
+++ b/tests/applicability_domain/leverage.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import LeverageADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -16,7 +17,7 @@ def test_inside_leverage_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -32,7 +33,7 @@ def test_outside_leverage_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/applicability_domain/pca_bounding_box.py
+++ b/tests/applicability_domain/pca_bounding_box.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import PCABoundingBoxADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -17,7 +18,7 @@ def test_inside_pca_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -33,7 +34,7 @@ def test_outside_pca_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 
@@ -59,7 +60,7 @@ def test_pca_options(n_components, whiten, random_state):
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 

--- a/tests/applicability_domain/prob_std.py
+++ b/tests/applicability_domain/prob_std.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from sklearn.datasets import (
     make_blobs,
     make_classification,
@@ -37,8 +38,7 @@ def test_inside_probstd_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.issubdtype(preds.dtype, np.bool_)
-    assert preds.shape == (len(X_test),)
-
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -64,8 +64,7 @@ def test_outside_probstd_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.issubdtype(preds.dtype, np.bool_)
-    assert preds.shape == (len(X_test),)
-
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 
@@ -83,7 +82,7 @@ def test_probstd_ad_with_default_model():
     preds = ad_checker.predict(X)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X),)
+    assert_equal(preds.shape, (len(X),))
 
 
 def test_ptobstd_ad_checker_with_classifier():
@@ -109,7 +108,7 @@ def test_ptobstd_ad_checker_with_classifier():
     preds = ad_checker.predict(X)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X),)
+    assert_equal(preds.shape, (len(X),))
 
 
 def test_probstd_fit():

--- a/tests/applicability_domain/response_variable_range.py
+++ b/tests/applicability_domain/response_variable_range.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import ResponseVariableRangeADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -19,7 +20,7 @@ def test_inside_response_range_ad():
     preds = ad_checker.predict(y_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(y_test),)
+    assert_equal(preds.shape, (len(y_test),))
     assert np.all(preds == 1)
 
 
@@ -37,7 +38,7 @@ def test_outside_response_range_ad():
     preds = ad_checker.predict(y_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(y_test),)
+    assert_equal(preds.shape, (len(y_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/applicability_domain/standard_deviation.py
+++ b/tests/applicability_domain/standard_deviation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from sklearn.datasets import (
     make_classification,
     make_multilabel_classification,
@@ -29,7 +30,7 @@ def test_inside_std_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -51,7 +52,7 @@ def test_outside_std_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 
@@ -68,7 +69,7 @@ def test_std_ad_with_default_model():
     preds = ad_checker.predict(X)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X),)
+    assert_equal(preds.shape, (len(X),))
 
 
 def test_std_ad_checker_with_classifier():
@@ -93,7 +94,7 @@ def test_std_ad_checker_with_classifier():
     preds = ad_checker.predict(X)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X),)
+    assert_equal(preds.shape, (len(X),))
 
 
 def test_std_ad_checker_with_multiclass():

--- a/tests/applicability_domain/topkat.py
+++ b/tests/applicability_domain/topkat.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from skfp.applicability_domain import TOPKATADChecker
 from tests.applicability_domain.utils import get_data_inside_ad, get_data_outside_ad
@@ -16,7 +17,7 @@ def test_inside_topkat_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 1)
 
 
@@ -32,7 +33,7 @@ def test_outside_topkat_ad():
     preds = ad_checker.predict(X_test)
     assert isinstance(preds, np.ndarray)
     assert np.isdtype(preds.dtype, np.bool)
-    assert preds.shape == (len(X_test),)
+    assert_equal(preds.shape, (len(X_test),))
     assert np.all(preds == 0)
 
 

--- a/tests/bases/base_filter.py
+++ b/tests/bases/base_filter.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
 from skfp.filters import LipinskiFilter
@@ -19,7 +20,7 @@ def test_base_transform_copy(smiles_list):
     filt = LipinskiFilter()
     filtered_smiles = filt.transform(smiles_list, copy=False)
     filtered_smiles_2 = filt.transform(smiles_list, copy=True)
-    assert filtered_smiles == filtered_smiles_2
+    assert_equal(filtered_smiles, filtered_smiles_2)
 
 
 def test_base_invalid_params(smiles_list):

--- a/tests/bases/base_fp_transformer.py
+++ b/tests/bases/base_fp_transformer.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.DataStructs import (
     IntSparseIntVect,
     LongSparseIntVect,
@@ -28,7 +28,7 @@ def test_base_transform_copy(smiles_list):
     atom_pair_fp = AtomPairFingerprint(n_jobs=-1)
     X_skfp = atom_pair_fp.transform(smiles_list, copy=False)
     X_skfp_2 = atom_pair_fp.transform(smiles_list, copy=True)
-    assert np.array_equal(X_skfp, X_skfp_2)
+    assert_equal(X_skfp, X_skfp_2)
 
 
 def test_base_invalid_params(smiles_list):

--- a/tests/bases/base_preprocessor.py
+++ b/tests/bases/base_preprocessor.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol, MolToSmiles
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -45,7 +46,7 @@ def test_base_flattened_results(n_jobs, verbose, smiles_list):
     results = mol_from_smiles.transform(smiles_list)
 
     assert isinstance(results, Sequence)
-    assert len(results) == len(smiles_list)
+    assert_equal(len(results), len(smiles_list))
     assert all(isinstance(elem, Mol) for elem in results)
 
 
@@ -77,4 +78,4 @@ def test_sequential_and_parallel_results(transformer_cls, inputs, verbose):
     seq_smiles = [MolToSmiles(mol) for mol in results_seq]
     par_smiles = [MolToSmiles(mol) for mol in results_par]
 
-    assert seq_smiles == par_smiles
+    assert_equal(seq_smiles, par_smiles)

--- a/tests/bases/base_substructure_fp.py
+++ b/tests/bases/base_substructure_fp.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -46,7 +47,7 @@ def test_substructure_count_fingerprint(
             [0, 0, 0, 0, 4, 0],
         ]
     )
-    assert np.array_equal(X_count, expected_count)
+    assert_equal(X_count, expected_count)
 
 
 def test_substructure_bit_fingerprint(
@@ -66,7 +67,7 @@ def test_substructure_bit_fingerprint(
             [0, 0, 0, 0, 1, 0],
         ]
     )
-    assert np.array_equal(X_bit, expected_bit)
+    assert_equal(X_bit, expected_bit)
 
 
 def test_substructure_sparse_count_fingerprint(
@@ -86,7 +87,7 @@ def test_substructure_sparse_count_fingerprint(
             [0, 0, 0, 0, 4, 0],
         ]
     )
-    assert np.array_equal(X_count.data, expected_count.data)
+    assert_equal(X_count.data, expected_count.data)
 
 
 def test_substructure_sparse_bit_fingerprint(
@@ -105,7 +106,7 @@ def test_substructure_sparse_bit_fingerprint(
             [0, 0, 0, 0, 1, 0],
         ]
     )
-    assert np.array_equal(X_bit.data, expected_bit.data)
+    assert_equal(X_bit.data, expected_bit.data)
 
 
 def test_parameter_constraints_enabled(

--- a/tests/datasets/lrgb.py
+++ b/tests/datasets/lrgb.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.datasets.lrgb import (
     load_lrgb_mol_benchmark,
@@ -23,11 +24,11 @@ def test_load_lrgb_benchmark():
     dataset_names = get_dataset_names()
     benchmark_full_dfs = load_lrgb_mol_benchmark(as_frames=True)
     benchmark_names = [name for name, df in benchmark_full_dfs]
-    assert benchmark_names == dataset_names
+    assert_equal(benchmark_names, dataset_names)
 
     benchmark_full_tuples = load_lrgb_mol_benchmark(as_frames=False)
     benchmark_names = [name for name, smiles, y in benchmark_full_tuples]
-    assert benchmark_names == dataset_names
+    assert_equal(benchmark_names, dataset_names)
 
 
 @pytest.mark.flaky(
@@ -85,7 +86,7 @@ def test_load_lrgb_splits_as_dict(dataset_name):
 def test_load_lrgb_splits_lengths(dataset_name, dataset_length):
     train, valid, test = load_lrgb_mol_splits(dataset_name)
     loaded_length = len(train) + len(valid) + len(test)
-    assert loaded_length == dataset_length
+    assert_equal(loaded_length, dataset_length)
 
 
 @pytest.mark.flaky(

--- a/tests/datasets/moleculenet.py
+++ b/tests/datasets/moleculenet.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
 from skfp.datasets.moleculenet import (
@@ -33,11 +34,11 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 def test_load_moleculenet_benchmark():
     benchmark_full = load_moleculenet_benchmark(as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
-    assert benchmark_names == MOLECULENET_DATASET_NAMES
+    assert_equal(benchmark_names, MOLECULENET_DATASET_NAMES)
 
     benchmark_full_tuples = load_moleculenet_benchmark(as_frames=False)
     benchmark_names = [name for name, smiles, y in benchmark_full_tuples]
-    assert benchmark_names == MOLECULENET_DATASET_NAMES
+    assert_equal(benchmark_names, MOLECULENET_DATASET_NAMES)
 
 
 @pytest.mark.flaky(
@@ -49,7 +50,7 @@ def test_load_moleculenet_benchmark_subset():
     dataset_names = ["ESOL", "SIDER", "BACE"]
     benchmark_full = load_moleculenet_benchmark(subset=dataset_names, as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
-    assert benchmark_names == dataset_names
+    assert_equal(benchmark_names, dataset_names)
 
 
 @pytest.mark.flaky(
@@ -130,7 +131,7 @@ def test_load_ogb_splits_as_dict(dataset_name):
 def test_load_ogb_splits_lengths(dataset_name, dataset_length):
     train, valid, test = load_ogb_splits(dataset_name)
     loaded_length = len(train) + len(valid) + len(test)
-    assert loaded_length == dataset_length
+    assert_equal(loaded_length, dataset_length)
 
 
 @pytest.mark.flaky(
@@ -201,7 +202,7 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 )
 def test_subset_to_dataset_names(subset_name, expected_num_datasets):
     subset_datasets = _subset_to_dataset_names(subset_name)
-    assert len(subset_datasets) == expected_num_datasets
+    assert_equal(len(subset_datasets), expected_num_datasets)
 
 
 def test_nonexistent_subset_name():

--- a/tests/datasets/tdc.py
+++ b/tests/datasets/tdc.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
 from skfp.datasets.tdc import load_tdc_benchmark, load_tdc_splits
@@ -60,11 +61,11 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 def test_load_tdc_benchmark():
     benchmark_full = load_tdc_benchmark(as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
-    assert benchmark_names == TDC_DATASET_NAMES
+    assert_equal(benchmark_names, TDC_DATASET_NAMES)
 
     benchmark_full_tuples = load_tdc_benchmark(as_frames=False)
     benchmark_names = [name for name, smiles, y in benchmark_full_tuples]
-    assert benchmark_names == TDC_DATASET_NAMES
+    assert_equal(benchmark_names, TDC_DATASET_NAMES)
 
 
 @pytest.mark.flaky(
@@ -76,7 +77,7 @@ def test_load_tdc_benchmark_subset():
     dataset_names = ["pampa_approved_drugs", "sarscov2_3clpro_diamond", "ames"]
     benchmark_full = load_tdc_benchmark(subset=dataset_names, as_frames=True)
     benchmark_names = [name for name, df in benchmark_full]
-    assert benchmark_names == dataset_names
+    assert_equal(benchmark_names, dataset_names)
 
 
 @pytest.mark.flaky(
@@ -181,7 +182,7 @@ def test_load_ogb_splits_as_dict(dataset_name):
 def test_load_tdc_splits_lengths(dataset_name, dataset_length):
     train, valid, test = load_tdc_splits(dataset_name)
     loaded_length = len(train) + len(valid) + len(test)
-    assert loaded_length == dataset_length
+    assert_equal(loaded_length, dataset_length)
 
 
 @pytest.mark.flaky(
@@ -192,8 +193,6 @@ def test_load_tdc_splits_lengths(dataset_name, dataset_length):
 def test_load_tdc_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
         load_tdc_splits("nonexistent")
-
-    print(str(error.value))
 
     assert str(error.value).startswith(
         "The 'dataset_name' parameter of load_tdc_splits must be a str among"
@@ -342,7 +341,7 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 )
 def test_subset_to_dataset_names(subset_name, expected_num_datasets):
     subset_datasets = _subset_to_dataset_names(subset_name)
-    assert len(subset_datasets) == expected_num_datasets
+    assert_equal(len(subset_datasets), expected_num_datasets)
 
 
 def test_nonexistent_subset_name():

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import Mol
 
 from skfp.preprocessing import MolFromSmilesTransformer
@@ -37,7 +38,7 @@ def run_basic_dataset_checks(
 def assert_valid_smiles_list(smiles_list: list[str], expected_length: int) -> None:
     assert isinstance(smiles_list, list)
     assert all(isinstance(s, str) for s in smiles_list)
-    assert len(smiles_list) == expected_length
+    assert_equal(len(smiles_list), expected_length)
 
 
 def assert_valid_mols_from_smiles(smiles_list: list[str]) -> None:
@@ -58,9 +59,9 @@ def assert_valid_labels(
     assert isinstance(y, np.ndarray)
 
     if num_tasks == 1:
-        assert y.shape == (expected_length,)
+        assert_equal(y.shape, (expected_length,))
     else:
-        assert y.shape == (expected_length, num_tasks)
+        assert_equal(y.shape, (expected_length, num_tasks))
 
     # note that in multioutput problems we allow NaN labels
     # it results in float dtype, instead of integer
@@ -102,10 +103,10 @@ def assert_valid_dataframe(
     assert isinstance(df, pd.DataFrame)
     if "aminoseq" in df.columns:
         # SMILES + aminoseq + labels
-        assert df.shape == (expected_length, num_tasks + 2)
+        assert_equal(df.shape, (expected_length, num_tasks + 2))
     else:
         # SMILES + labels
-        assert df.shape == (expected_length, num_tasks + 1)
+        assert_equal(df.shape, (expected_length, num_tasks + 1))
 
     assert "SMILES" in df.columns
 
@@ -115,5 +116,5 @@ def assert_valid_dataframe(
     if num_tasks == 1:
         df_y = df_y.ravel()
 
-    assert df_smiles == smiles_list
-    assert np.array_equal(df_y, y, equal_nan=True)
+    assert_equal(df_smiles, smiles_list)
+    assert_allclose(df_y, y, equal_nan=True)

--- a/tests/datasets/utils.py
+++ b/tests/datasets/utils.py
@@ -4,6 +4,7 @@ import shutil
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.datasets.utils import (
     fetch_splits,
@@ -21,7 +22,7 @@ def test_get_data_home_dir():
     finally:
         shutil.rmtree("data")
 
-    assert custom_dir == os.path.join("data", "test")
+    assert_equal(custom_dir, os.path.join("data", "test"))
 
 
 def test_fetch_splits(capsys):
@@ -40,17 +41,18 @@ def test_fetch_splits(capsys):
 def test_get_smiles_and_labels(mol_type):
     df = pd.DataFrame({mol_type: ["a", "b", "c"], "label": [0, 0, 1]})
     smiles_list, y = get_mol_strings_and_labels(df, mol_type=mol_type)
-    assert smiles_list == ["a", "b", "c"]
-    assert y.ndim == 1
-    assert np.array_equal(y, np.array([0, 0, 1]))
+    assert_equal(smiles_list, ["a", "b", "c"])
+    assert_equal(y.ndim, 1)
+    assert_equal(y, np.array([0, 0, 1]))
 
     df = pd.DataFrame(
         {mol_type: ["a", "b", "c"], "label1": [0, 1, 1], "label2": [1, 1, 0]}
     )
     smiles_list, y = get_mol_strings_and_labels(df, mol_type=mol_type)
-    assert smiles_list == ["a", "b", "c"]
-    assert y.ndim == 2
-    assert np.array_equal(y, np.array([[0, 1], [1, 1], [1, 0]]))
+
+    assert_equal(smiles_list, ["a", "b", "c"])
+    assert_equal(y.ndim, 2)
+    assert_equal(y, np.array([[0, 1], [1, 1], [1, 0]]))
 
 
 def test_wrong_mol_type():

--- a/tests/descriptors/constitutional.py
+++ b/tests/descriptors/constitutional.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import Mol, MolFromSmiles
 
 from skfp.descriptors import constitutional as const
@@ -72,7 +73,7 @@ def test_average_molecular_weight_empty_molecule(input_mols):
 def test_bond_count(mol_name, bond_type, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.bond_count(mol, bond_type)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -90,7 +91,7 @@ def test_bond_count(mol_name, bond_type, expected_value, input_mols):
 def test_element_atom_count(mol_name, atom_id, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.element_atom_count(mol, atom_id)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -108,7 +109,7 @@ def test_element_atom_count(mol_name, atom_id, expected_value, input_mols):
 def test_heavy_atom_count(mol_name, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.heavy_atom_count(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -126,7 +127,7 @@ def test_heavy_atom_count(mol_name, expected_value, input_mols):
 def test_molecular_weight(mol_name, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.molecular_weight(mol)
-    assert round(result, 3) == round(expected_value, 3)
+    assert_allclose(result, expected_value, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -143,7 +144,7 @@ def test_molecular_weight(mol_name, expected_value, input_mols):
 def test_number_of_rings(mol_name, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.number_of_rings(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -160,7 +161,7 @@ def test_number_of_rings(mol_name, expected_value, input_mols):
 def test_number_of_rotatable_bonds(mol_name, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.number_of_rotatable_bonds(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -178,4 +179,4 @@ def test_number_of_rotatable_bonds(mol_name, expected_value, input_mols):
 def test_total_atom_count(mol_name, expected_value, input_mols):
     mol = input_mols[mol_name]
     result = const.total_atom_count(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)

--- a/tests/descriptors/topological.py
+++ b/tests/descriptors/topological.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import GetDistanceMatrix, Mol, MolFromSmiles
 
 from skfp.descriptors import burden_matrix
@@ -48,8 +49,8 @@ def test_wiener_index(mol_name, expected_value, input_mols):
     result = top.wiener_index(mol, distance_matrix)
     result_no_dist_matrix = top.wiener_index(mol)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -71,8 +72,8 @@ def test_average_wiener_index(mol_name, expected_value, input_mols):
     result = top.average_wiener_index(mol, distance_matrix)
     result_no_dist_matrix = top.average_wiener_index(mol)
 
-    assert round(result, 3) == expected_value
-    assert round(result_no_dist_matrix, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
+    assert_allclose(result_no_dist_matrix, expected_value, atol=1e-3)
 
 
 def test_average_wiener_index_single_atom(input_mols):
@@ -104,8 +105,8 @@ def test_balaban_j_index(mol_name, expected_value, input_mols):
     result = top.balaban_j_index(mol)
     result_no_dist_matrix = top.balaban_j_index(mol)
 
-    assert round(result, 3) == expected_value
-    assert round(result_no_dist_matrix, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
+    assert_allclose(result_no_dist_matrix, expected_value, atol=1e-3)
 
 
 def test_burden_wrong_descriptors():
@@ -144,8 +145,8 @@ def test_diameter(mol_name, expected_value, input_mols):
     result = top.diameter(mol, distance_matrix)
     result_no_dist_matrix = top.diameter(mol)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -168,8 +169,8 @@ def test_graph_distance_index(mol_name, expected_value, input_mols):
     result = top.graph_distance_index(mol, distance_matrix)
     result_no_dist_matrix = top.graph_distance_index(mol)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -193,7 +194,7 @@ def test_petitjean_index(mol_name, expected_value, input_mols):
     result_no_dist_matrix = top.petitjean_index(mol)
 
     assert round(result, 3) == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -216,8 +217,8 @@ def test_radius(mol_name, expected_value, input_mols):
     result = top.radius(mol, distance_matrix)
     result_no_dist_matrix = top.radius(mol)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -236,8 +237,7 @@ def test_radius(mol_name, expected_value, input_mols):
 def test_hall_kier_alpha(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.hall_kier_alpha(mol)
-
-    assert round(result, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -256,8 +256,7 @@ def test_hall_kier_alpha(mol_name, expected_value, input_mols):
 def test_kappa1_index(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.kappa1_index(mol)
-
-    assert round(result, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -277,7 +276,7 @@ def test_kappa2_index(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.kappa2_index(mol)
 
-    assert round(result, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -296,8 +295,7 @@ def test_kappa2_index(mol_name, expected_value, input_mols):
 def test_kappa3_index(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.kappa3_index(mol)
-
-    assert round(result, 3) == expected_value
+    assert_allclose(result, expected_value, atol=1e-3)
 
 
 @pytest.mark.parametrize(
@@ -317,7 +315,7 @@ def test_kappa3_index(mol_name, expected_value, input_mols):
 def test_zagreb_index_m1(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.zagreb_index_m1(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -337,7 +335,7 @@ def test_zagreb_index_m1(mol_name, expected_value, input_mols):
 def test_zagreb_index_m2(mol_name, expected_value, input_mols):
     mol, _ = input_mols[mol_name]
     result = top.zagreb_index_m2(mol)
-    assert result == expected_value
+    assert_equal(result, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -360,8 +358,8 @@ def test_polarity_number(mol_name, expected_value, input_mols):
     result = top.polarity_number(mol, distance_matrix)
     result_no_dist_matrix = top.polarity_number(mol)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 @pytest.mark.parametrize(
@@ -380,8 +378,8 @@ def test_polarity_number_carbon_only(mol_name, expected_value, input_mols):
     result = top.polarity_number(mol, distance_matrix, carbon_only=True)
     result_no_dist_matrix = top.polarity_number(mol, carbon_only=True)
 
-    assert result == expected_value
-    assert result_no_dist_matrix == expected_value
+    assert_equal(result, expected_value)
+    assert_equal(result_no_dist_matrix, expected_value)
 
 
 def test_polarity_number_no_carbon(input_mols):

--- a/tests/distances/common.py
+++ b/tests/distances/common.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from scipy.sparse import csr_array
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import NearestNeighbors
@@ -46,7 +47,7 @@ def test_sklearn_nearest_neighbors_compatible(dist_func):
     nn.fit(vec_a)
     distances, _ = nn.kneighbors(vec_b)
     sklearn_dist = distances[0][0]
-    assert np.isclose(skfp_dist, sklearn_dist)
+    assert_allclose(skfp_dist, sklearn_dist)
 
 
 @pytest.mark.parametrize("dist_func", _get_distance_functions())
@@ -59,7 +60,7 @@ def test_sklearn_nearest_neighbors_compatible_sparse_csr(dist_func):
     nn.fit(vec_a)
     distances, _ = nn.kneighbors(vec_b)
     sklearn_dist = distances[0][0]
-    assert np.isclose(skfp_dist, sklearn_dist)
+    assert_allclose(skfp_dist, sklearn_dist)
 
 
 @pytest.mark.parametrize("dist_func", _get_distance_functions())

--- a/tests/distances/fraggle.py
+++ b/tests/distances/fraggle.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from rdkit.Chem import Mol, MolFromSmiles
 
 from skfp.distances import (
@@ -56,8 +56,8 @@ def test_bulk_fraggle(mols_list):
     bulk_sim = bulk_fraggle_similarity(mols_list)
     bulk_dist = bulk_fraggle_distance(mols_list)
 
-    assert np.allclose(pairwise_sim, bulk_sim)
-    assert np.allclose(pairwise_dist, bulk_dist)
+    assert_allclose(pairwise_sim, bulk_sim, atol=1e-3)
+    assert_allclose(pairwise_dist, bulk_dist, atol=1e-3)
 
 
 def test_bulk_fraggle_second_list(mols_list):
@@ -65,4 +65,5 @@ def test_bulk_fraggle_second_list(mols_list):
 
     bulk_sim_single = bulk_fraggle_similarity(mols_list)
     bulk_sim_two = bulk_fraggle_similarity(mols_list, mols_list)
-    assert np.allclose(bulk_sim_single, bulk_sim_two)
+
+    assert_allclose(bulk_sim_single, bulk_sim_two, atol=1e-3)

--- a/tests/distances/mcs.py
+++ b/tests/distances/mcs.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from rdkit.Chem import Mol, MolFromSmiles
 
 from skfp.distances import (
@@ -56,8 +56,8 @@ def test_bulk_mcs(mols_list):
     bulk_sim = bulk_mcs_similarity(mols_list)
     bulk_dist = bulk_mcs_distance(mols_list)
 
-    assert np.allclose(pairwise_sim, bulk_sim)
-    assert np.allclose(pairwise_dist, bulk_dist)
+    assert_allclose(pairwise_sim, bulk_sim, atol=1e-3)
+    assert_allclose(pairwise_dist, bulk_dist, atol=1e-3)
 
 
 def test_bulk_mcs_second_list(mols_list):
@@ -65,4 +65,5 @@ def test_bulk_mcs_second_list(mols_list):
 
     bulk_sim_single = bulk_mcs_similarity(mols_list)
     bulk_sim_two = bulk_mcs_similarity(mols_list, mols_list)
-    assert np.allclose(bulk_sim_single, bulk_sim_two)
+
+    assert_allclose(bulk_sim_single, bulk_sim_two, atol=1e-3)

--- a/tests/distances/utils.py
+++ b/tests/distances/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 import numpy as np
+from numpy.testing import assert_allclose
 from rdkit.Chem import Mol
 from scipy.sparse import csr_array
 
@@ -28,14 +29,14 @@ def run_test_similarity_and_distance(
     sim_sparse = sim_func(vec_a_sparse, vec_b_sparse, **sim_func_kwargs)
     dist_sparse = dist_func(vec_a_sparse, vec_b_sparse)
 
-    assert np.isclose(sim_dense, similarity, atol=1e-3)
-    assert np.isclose(sim_sparse, similarity, atol=1e-3)
+    assert_allclose(sim_dense, similarity, atol=1e-3)
+    assert_allclose(sim_sparse, similarity, atol=1e-3)
 
-    assert np.isclose(dist_dense, distance, atol=1e-3)
-    assert np.isclose(dist_sparse, distance, atol=1e-3)
+    assert_allclose(dist_dense, distance, atol=1e-3)
+    assert_allclose(dist_sparse, distance, atol=1e-3)
 
-    assert np.isclose(sim_dense, sim_sparse)
-    assert np.isclose(dist_dense, dist_sparse)
+    assert_allclose(sim_dense, sim_sparse)
+    assert_allclose(dist_dense, dist_sparse)
 
 
 def run_test_bulk_similarity_and_distance(
@@ -68,11 +69,11 @@ def run_test_bulk_similarity_and_distance(
     bulk_sim_sparse = bulk_sim_func(fps_sparse, **sim_func_kwargs)
     bulk_dist_sparse = bulk_dist_func(fps_sparse)
 
-    assert np.allclose(expected_sim, bulk_sim, atol=1e-3)
-    assert np.allclose(expected_dist, bulk_dist, atol=1e-3)
+    assert_allclose(expected_sim, bulk_sim, atol=1e-3)
+    assert_allclose(expected_dist, bulk_dist, atol=1e-3)
 
-    assert np.allclose(bulk_sim, bulk_sim_sparse, atol=1e-3)
-    assert np.allclose(bulk_dist, bulk_dist_sparse, atol=1e-3)
+    assert_allclose(bulk_sim, bulk_sim_sparse, atol=1e-3)
+    assert_allclose(bulk_dist, bulk_dist_sparse, atol=1e-3)
 
 
 def run_test_bulk_similarity_and_distance_two_arrays(
@@ -106,8 +107,8 @@ def run_test_bulk_similarity_and_distance_two_arrays(
     bulk_sim_sparse = bulk_sim_func(fps_sparse_1, fps_sparse_2, **sim_func_kwargs)
     bulk_dist_sparse = bulk_dist_func(fps_sparse_1, fps_sparse_2)
 
-    assert np.allclose(expected_sim, bulk_sim, atol=1e-3)
-    assert np.allclose(expected_dist, bulk_dist, atol=1e-3)
+    assert_allclose(expected_sim, bulk_sim, atol=1e-3)
+    assert_allclose(expected_dist, bulk_dist, atol=1e-3)
 
-    assert np.allclose(bulk_sim, bulk_sim_sparse, atol=1e-3)
-    assert np.allclose(bulk_dist, bulk_dist_sparse, atol=1e-3)
+    assert_allclose(bulk_sim, bulk_sim_sparse, atol=1e-3)
+    assert_allclose(bulk_dist, bulk_dist_sparse, atol=1e-3)

--- a/tests/filters/beyond_ro5.py
+++ b/tests/filters/beyond_ro5.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.filters import BeyondRo5Filter, LipinskiFilter
@@ -62,31 +63,31 @@ def test_mols_passing_bro5(smiles_passing_ro5, smiles_failing_ro5, smiles_beyond
 
     smiles_filtered = filt.transform(smiles_passing_ro5)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_ro5)
+    assert_equal(len(smiles_filtered), len(smiles_passing_ro5))
 
     smiles_filtered = filt.transform(smiles_failing_ro5)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_failing_ro5)
+    assert_equal(len(smiles_filtered), len(smiles_failing_ro5))
 
     smiles_filtered = filt.transform(smiles_beyond_ro5)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_beyond_ro5)
+    assert_equal(len(smiles_filtered), len(smiles_beyond_ro5))
 
 
 def test_mols_ro5_vs_bro5(smiles_passing_ro5, smiles_failing_ro5, smiles_beyond_ro5):
     all_smiles = smiles_passing_ro5 + smiles_failing_ro5 + smiles_beyond_ro5
 
     filt_ro5 = LipinskiFilter()
-    assert len(filt_ro5.transform(smiles_passing_ro5)) == 3
-    assert len(filt_ro5.transform(smiles_failing_ro5)) == 0
-    assert len(filt_ro5.transform(smiles_beyond_ro5)) == 0
-    assert len(filt_ro5.transform(all_smiles)) == 3
+    assert_equal(len(filt_ro5.transform(smiles_passing_ro5)), 3)
+    assert_equal(len(filt_ro5.transform(smiles_failing_ro5)), 0)
+    assert_equal(len(filt_ro5.transform(smiles_beyond_ro5)), 0)
+    assert_equal(len(filt_ro5.transform(all_smiles)), 3)
 
     filt_bro5 = BeyondRo5Filter()
-    assert len(filt_bro5.transform(smiles_passing_ro5)) == 3
-    assert len(filt_bro5.transform(smiles_failing_ro5)) == 3
-    assert len(filt_bro5.transform(smiles_beyond_ro5)) == 3
-    assert len(filt_bro5.transform(all_smiles)) == 9
+    assert_equal(len(filt_bro5.transform(smiles_passing_ro5)), 3)
+    assert_equal(len(filt_bro5.transform(smiles_failing_ro5)), 3)
+    assert_equal(len(filt_bro5.transform(smiles_beyond_ro5)), 3)
+    assert_equal(len(filt_bro5.transform(all_smiles)), 9)
 
 
 def test_bro5_smiles_and_mol_input(smiles_list, mols_list):
@@ -96,7 +97,7 @@ def test_bro5_smiles_and_mol_input(smiles_list, mols_list):
 
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert all(isinstance(x, Mol) for x in mols_filtered)
-    assert len(smiles_filtered) == len(mols_filtered)
+    assert_equal(len(smiles_filtered), len(mols_filtered))
 
 
 def test_bro5_parallel(smiles_list):
@@ -106,7 +107,7 @@ def test_bro5_parallel(smiles_list):
     filt = BeyondRo5Filter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = filt.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_mols_loose_bro5(mols_list):
@@ -127,7 +128,7 @@ def test_bro5_return_indicators(
     filt = BeyondRo5Filter(return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
 
-    assert len(filter_indicators) == len(all_smiles)
+    assert_equal(len(filter_indicators), len(all_smiles))
     assert isinstance(filter_indicators, np.ndarray)
     assert np.issubdtype(filter_indicators.dtype, bool)
     assert np.all(np.isin(filter_indicators, [0, 1]))
@@ -141,12 +142,12 @@ def test_bro5_transform_x_y(smiles_passing_ro5, smiles_failing_beyond_ro5):
 
     filt = BeyondRo5Filter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_ro5)
+    assert_equal(len(mols), len(smiles_passing_ro5))
     assert np.all(labels_filt == 1)
 
     filt = BeyondRo5Filter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_ro5)
+    assert_equal(np.sum(indicators), len(smiles_passing_ro5))
     assert np.array_equal(indicators, labels_filt)
 
 
@@ -155,7 +156,7 @@ def test_bro5_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (6,)
+    assert_equal(condition_names.shape, (6,))
 
 
 def test_bro5_return_condition_indicators(
@@ -167,7 +168,7 @@ def test_bro5_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -184,7 +185,7 @@ def test_bro5_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/faf4_druglike.py
+++ b/tests/filters/faf4_druglike.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import FAF4DruglikeFilter
 
@@ -42,7 +43,7 @@ def test_mols_passing_faf4_druglike(smiles_passing_faf4_druglike):
     mol_filter = FAF4DruglikeFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_faf4_druglike)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_faf4_druglike)
+    assert_equal(len(smiles_filtered), len(smiles_passing_faf4_druglike))
 
 
 def test_mols_partially_passing_faf4_druglike(
@@ -51,14 +52,14 @@ def test_mols_partially_passing_faf4_druglike(
     mol_filter = FAF4DruglikeFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_faf4_druglike)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_violation_faf4_druglike)
+    assert_equal(len(smiles_filtered), len(smiles_passing_one_violation_faf4_druglike))
 
 
 def test_mols_failing_faf4_druglike(smiles_failing_faf4_druglike):
     mol_filter = FAF4DruglikeFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_faf4_druglike)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_faf4_druglike_return_indicators(
@@ -80,7 +81,7 @@ def test_faf4_druglike_return_indicators(
         + [False] * len(smiles_passing_one_violation_faf4_druglike),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = FAF4DruglikeFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -90,7 +91,7 @@ def test_faf4_druglike_return_indicators(
         + [True] * len(smiles_passing_one_violation_faf4_druglike),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_faf4_druglike_parallel(smiles_list):
@@ -100,7 +101,7 @@ def test_faf4_druglike_parallel(smiles_list):
     mol_filter = FAF4DruglikeFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_faf4_druglike_transform_x_y(
@@ -114,13 +115,13 @@ def test_faf4_druglike_transform_x_y(
 
     filt = FAF4DruglikeFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_faf4_druglike)
+    assert_equal(len(mols), len(smiles_passing_faf4_druglike))
     assert np.all(labels_filt == 1)
 
     filt = FAF4DruglikeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_faf4_druglike)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_faf4_druglike))
+    assert_equal(indicators, labels_filt)
 
 
 def test_faf4_druglike_condition_names():
@@ -128,7 +129,7 @@ def test_faf4_druglike_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (14,)
+    assert_equal(condition_names.shape, (14,))
 
 
 def test_faf4_druglike_return_condition_indicators(
@@ -140,7 +141,7 @@ def test_faf4_druglike_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 14)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 14))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -158,7 +159,7 @@ def test_faf4_druglike_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 14)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 14))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/faf4_leadlike.py
+++ b/tests/filters/faf4_leadlike.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import FAF4LeadlikeFilter
 
@@ -34,14 +35,14 @@ def test_mols_passing_faf4_leadlike(smiles_passing_faf4_leadlike):
     mol_filter = FAF4LeadlikeFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_faf4_leadlike)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_faf4_leadlike)
+    assert_equal(len(smiles_filtered), len(smiles_passing_faf4_leadlike))
 
 
 def test_mols_failing_faf4_leadlike(smiles_failing_faf4_leadlike):
     mol_filter = FAF4LeadlikeFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_faf4_leadlike)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_faf4_leadlike_return_indicators(
@@ -57,7 +58,7 @@ def test_faf4_leadlike_return_indicators(
         + [False] * len(smiles_failing_faf4_leadlike),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_faf4_leadlike_parallel(smiles_list):
@@ -67,7 +68,7 @@ def test_faf4_leadlike_parallel(smiles_list):
     mol_filter = FAF4LeadlikeFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_faf4_leadlike_allow_one_violation(smiles_failing_faf4_leadlike):
@@ -77,7 +78,7 @@ def test_faf4_leadlike_allow_one_violation(smiles_failing_faf4_leadlike):
     mol_filter = FAF4LeadlikeFilter(allow_one_violation=True)
     mols_filtered_one_violation = mol_filter.transform(smiles_failing_faf4_leadlike)
 
-    assert mols_filtered == mols_filtered_one_violation
+    assert_equal(mols_filtered, mols_filtered_one_violation)
 
 
 def test_faf4_leadlike_transform_x_y(
@@ -91,13 +92,13 @@ def test_faf4_leadlike_transform_x_y(
 
     filt = FAF4LeadlikeFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_faf4_leadlike)
+    assert_equal(len(mols), len(smiles_passing_faf4_leadlike))
     assert np.all(labels_filt == 1)
 
     filt = FAF4LeadlikeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_faf4_leadlike)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_faf4_leadlike))
+    assert_equal(indicators, labels_filt)
 
 
 def test_faf4_leadlike_condition_names():
@@ -105,7 +106,7 @@ def test_faf4_leadlike_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (15,)
+    assert_equal(condition_names.shape, (15,))
 
 
 def test_faf4_leadlike_return_condition_indicators(
@@ -117,7 +118,7 @@ def test_faf4_leadlike_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 15)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 15))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -135,7 +136,7 @@ def test_faf4_leadlike_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 15)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 15))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/ghose.py
+++ b/tests/filters/ghose.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import GhoseFilter
 
@@ -37,14 +38,14 @@ def test_mols_passing_ghose(
     mol_filter = GhoseFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_ghose)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_ghose)
+    assert_equal(len(smiles_filtered), len(smiles_passing_ghose))
 
 
 def test_mols_failing_ghose(smiles_failing_ghose):
     mol_filter = GhoseFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_ghose)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_ghose(
@@ -52,11 +53,11 @@ def test_mols_passing_with_violation_ghose(
 ):
     mol_filter = GhoseFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_ghose)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = GhoseFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_ghose)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_ghose_return_indicators(
@@ -76,7 +77,7 @@ def test_ghose_return_indicators(
         + [False] * len(smiles_passing_one_violation_ghose),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = GhoseFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -86,7 +87,7 @@ def test_ghose_return_indicators(
         + [True] * len(smiles_passing_one_violation_ghose),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_ghose_parallel(smiles_list):
@@ -96,7 +97,7 @@ def test_ghose_parallel(smiles_list):
     mol_filter = GhoseFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_ghose_transform_x_y(smiles_passing_ghose, smiles_failing_ghose):
@@ -105,13 +106,13 @@ def test_ghose_transform_x_y(smiles_passing_ghose, smiles_failing_ghose):
 
     filt = GhoseFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_ghose)
+    assert_equal(len(mols), len(smiles_passing_ghose))
     assert np.all(labels_filt == 1)
 
     filt = GhoseFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_ghose)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_ghose))
+    assert_equal(indicators, labels_filt)
 
 
 def test_ghose_condition_names():
@@ -119,7 +120,7 @@ def test_ghose_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (4,)
+    assert_equal(condition_names.shape, (4,))
 
 
 def test_ghose_return_condition_indicators(smiles_passing_ghose, smiles_failing_ghose):
@@ -129,7 +130,7 @@ def test_ghose_return_condition_indicators(smiles_passing_ghose, smiles_failing_
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -144,7 +145,7 @@ def test_ghose_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/gsk.py
+++ b/tests/filters/gsk.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import GSKFilter
 
@@ -33,21 +34,21 @@ def test_mols_passing_gsk(smiles_passing_gsk):
     mol_filter = GSKFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_gsk)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_gsk)
+    assert_equal(len(smiles_filtered), len(smiles_passing_gsk))
 
 
 def test_mols_partially_passing_gsk(smiles_passing_one_fail):
     mol_filter = GSKFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_fail)
+    assert_equal(len(smiles_filtered), len(smiles_passing_one_fail))
 
 
 def test_mols_failing_gsk(smiles_failing_gsk):
     mol_filter = GSKFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_gsk)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_gsk_return_indicators(
@@ -65,7 +66,7 @@ def test_gsk_return_indicators(
         + [False] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = GSKFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -75,7 +76,7 @@ def test_gsk_return_indicators(
         + [True] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_gsk_parallel(smiles_list):
@@ -85,7 +86,7 @@ def test_gsk_parallel(smiles_list):
     mol_filter = GSKFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_gsk_transform_x_y(smiles_passing_gsk, smiles_failing_gsk):
@@ -94,13 +95,13 @@ def test_gsk_transform_x_y(smiles_passing_gsk, smiles_failing_gsk):
 
     filt = GSKFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_gsk)
+    assert_equal(len(mols), len(smiles_passing_gsk))
     assert np.all(labels_filt == 1)
 
     filt = GSKFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_gsk)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_gsk))
+    assert_equal(indicators, labels_filt)
 
 
 def test_gsk_condition_names():
@@ -108,7 +109,7 @@ def test_gsk_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (2,)
+    assert_equal(condition_names.shape, (2,))
 
 
 def test_gsk_return_condition_indicators(smiles_passing_gsk, smiles_failing_gsk):
@@ -118,7 +119,7 @@ def test_gsk_return_condition_indicators(smiles_passing_gsk, smiles_failing_gsk)
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -133,7 +134,7 @@ def test_gsk_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/hao.py
+++ b/tests/filters/hao.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import HaoFilter
 
@@ -37,14 +38,14 @@ def test_mols_passing_hao(
     mol_filter = HaoFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_hao)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_hao)
+    assert_equal(len(smiles_filtered), len(smiles_passing_hao))
 
 
 def test_mols_failing_hao(smiles_failing_hao):
     mol_filter = HaoFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_hao)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_hao(
@@ -52,11 +53,11 @@ def test_mols_passing_with_violation_hao(
 ):
     mol_filter = HaoFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_hao)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = HaoFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_hao)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_hao_return_indicators(
@@ -76,7 +77,7 @@ def test_hao_return_indicators(
         + [False] * len(smiles_passing_one_violation_hao),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = HaoFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -86,7 +87,7 @@ def test_hao_return_indicators(
         + [True] * len(smiles_passing_one_violation_hao),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_hao_parallel(smiles_list):
@@ -96,7 +97,7 @@ def test_hao_parallel(smiles_list):
     mol_filter = HaoFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_hao_transform_x_y(smiles_passing_hao, smiles_failing_hao):
@@ -105,13 +106,13 @@ def test_hao_transform_x_y(smiles_passing_hao, smiles_failing_hao):
 
     filt = HaoFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_hao)
+    assert_equal(len(mols), len(smiles_passing_hao))
     assert np.all(labels_filt == 1)
 
     filt = HaoFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_hao)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_hao))
+    assert_equal(indicators, labels_filt)
 
 
 def test_hao_condition_names():
@@ -119,7 +120,7 @@ def test_hao_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (6,)
+    assert_equal(condition_names.shape, (6,))
 
 
 def test_hao_return_condition_indicators(smiles_passing_hao, smiles_failing_hao):
@@ -129,7 +130,7 @@ def test_hao_return_condition_indicators(smiles_passing_hao, smiles_failing_hao)
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -144,7 +145,7 @@ def test_hao_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/lipinski.py
+++ b/tests/filters/lipinski.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.filters import LipinskiFilter
@@ -47,23 +48,24 @@ def test_mols_passing_lipinski(smiles_passing_lipinski):
     smiles_filtered = filt.transform(smiles_passing_lipinski)
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert len(smiles_filtered) == len(smiles_passing_lipinski)
+    assert_equal(len(smiles_filtered), len(smiles_passing_lipinski))
 
 
 def test_mols_failing_lipinski(smiles_failing_lipinski):
     filt = LipinskiFilter()
     smiles_filtered = filt.transform(smiles_failing_lipinski)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_failing_strict_lipinski(smiles_one_lipinski_violation):
     filt = LipinskiFilter()
     smiles_filtered = filt.transform(smiles_one_lipinski_violation)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     filt = LipinskiFilter(allow_one_violation=False)
     smiles_filtered = filt.transform(smiles_one_lipinski_violation)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_lipinski_various_conditions(
@@ -77,11 +79,11 @@ def test_mols_lipinski_various_conditions(
 
     filt = LipinskiFilter()
     mols_filtered = filt.transform(all_smiles)
-    assert len(mols_filtered) == 6
+    assert_equal(len(mols_filtered), 6)
 
     filt = LipinskiFilter(allow_one_violation=False)
     mols_filtered = filt.transform(all_smiles)
-    assert len(mols_filtered) == 3
+    assert_equal(len(mols_filtered), 3)
 
 
 def test_lipinski_smiles_and_mol_input(smiles_list, mols_list):
@@ -91,7 +93,7 @@ def test_lipinski_smiles_and_mol_input(smiles_list, mols_list):
 
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert all(isinstance(x, Mol) for x in mols_filtered)
-    assert len(smiles_filtered) == len(mols_filtered)
+    assert_equal(len(smiles_filtered), len(mols_filtered))
 
 
 def test_lipinski_parallel(smiles_list):
@@ -101,7 +103,7 @@ def test_lipinski_parallel(smiles_list):
     filt = LipinskiFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = filt.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_lipinski_return_indicators(
@@ -121,7 +123,7 @@ def test_lipinski_return_indicators(
         + [True] * len(smiles_one_lipinski_violation),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     filt = LipinskiFilter(allow_one_violation=False, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
@@ -131,7 +133,7 @@ def test_lipinski_return_indicators(
         + [False] * len(smiles_one_lipinski_violation),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_lipinski_transform_x_y(smiles_passing_lipinski, smiles_failing_lipinski):
@@ -142,13 +144,13 @@ def test_lipinski_transform_x_y(smiles_passing_lipinski, smiles_failing_lipinski
 
     filt = LipinskiFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_lipinski)
+    assert_equal(len(mols), len(smiles_passing_lipinski))
     assert np.all(labels_filt == 1)
 
     filt = LipinskiFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_lipinski)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_lipinski))
+    assert_equal(indicators, labels_filt)
 
 
 def test_lipinski_condition_names():
@@ -156,7 +158,7 @@ def test_lipinski_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (4,)
+    assert_equal(condition_names.shape, (4,))
 
 
 def test_lipinski_return_condition_indicators(
@@ -168,7 +170,7 @@ def test_lipinski_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -185,7 +187,7 @@ def test_lipinski_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/mol_weight.py
+++ b/tests/filters/mol_weight.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -63,20 +64,20 @@ def test_mol_weight_thresholds(
 
     smiles_light_filtered = filt.transform(smiles_light_mols)
     assert all(isinstance(x, str) for x in smiles_light_filtered)
-    assert len(smiles_light_filtered) == len(smiles_light_mols)
-    assert len(smiles_light_filtered) == 3
+    assert_equal(len(smiles_light_filtered), len(smiles_light_mols))
+    assert_equal(len(smiles_light_filtered), 3)
 
     smiles_medium_filtered = filt.transform(smiles_medium_mols)
     assert all(isinstance(x, str) for x in smiles_medium_filtered)
-    assert len(smiles_medium_filtered) == len(smiles_medium_mols)
-    assert len(smiles_medium_filtered) == 3
+    assert_equal(len(smiles_medium_filtered), len(smiles_medium_mols))
+    assert_equal(len(smiles_medium_filtered), 3)
 
     smiles_heavy_filtered = filt.transform(smiles_heavy_mols)
-    assert len(smiles_heavy_filtered) == 0
+    assert_equal(len(smiles_heavy_filtered), 0)
 
     all_smiles = smiles_light_mols + smiles_medium_mols + smiles_heavy_mols
     all_smiles_filtered = filt.transform(all_smiles)
-    assert len(all_smiles_filtered) == 6
+    assert_equal(len(all_smiles_filtered), 6)
 
 
 def test_mol_weight_smiles_and_mol_input(
@@ -92,8 +93,8 @@ def test_mol_weight_smiles_and_mol_input(
 
     assert all(isinstance(x, str) for x in smiles_filtered)
     assert all(isinstance(x, Mol) for x in mols_filtered)
-    assert len(smiles_filtered) == len(mols_filtered)
-    assert len(smiles_filtered) == 6
+    assert_equal(len(smiles_filtered), len(mols_filtered))
+    assert_equal(len(smiles_filtered), 6)
 
 
 def test_mol_weight_parallel(smiles_light_mols, smiles_medium_mols, smiles_heavy_mols):
@@ -104,7 +105,7 @@ def test_mol_weight_parallel(smiles_light_mols, smiles_medium_mols, smiles_heavy
     filt = MolecularWeightFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = filt.transform(all_smiles)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_mol_weight_return_indicators(
@@ -120,7 +121,7 @@ def test_mol_weight_return_indicators(
         + [False] * len(smiles_heavy_mols),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     filt = MolecularWeightFilter(max_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
@@ -130,7 +131,7 @@ def test_mol_weight_return_indicators(
         + [False] * len(smiles_heavy_mols),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_mol_weight_min_max_thresholds(
@@ -146,7 +147,7 @@ def test_mol_weight_min_max_thresholds(
         + [False] * len(smiles_heavy_mols),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     filt = MolecularWeightFilter(max_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
@@ -156,7 +157,7 @@ def test_mol_weight_min_max_thresholds(
         + [False] * len(smiles_heavy_mols),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     filt = MolecularWeightFilter(min_weight=500, return_type="indicators")
     filter_indicators = filt.transform(all_smiles)
@@ -166,7 +167,7 @@ def test_mol_weight_min_max_thresholds(
         + [False] * len(smiles_heavy_mols),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_mol_weight_wrong_min_max_thresholds(smiles_list):
@@ -187,13 +188,13 @@ def test_mol_weight_transform_x_y(smiles_light_mols, smiles_heavy_mols):
 
     filt = MolecularWeightFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_light_mols)
+    assert_equal(len(mols), len(smiles_light_mols))
     assert np.all(labels_filt == 1)
 
     filt = MolecularWeightFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_light_mols)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_light_mols))
+    assert_equal(indicators, labels_filt)
 
 
 def test_mol_weight_condition_names():
@@ -201,7 +202,7 @@ def test_mol_weight_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (1,)
+    assert_equal(condition_names.shape, (1,))
 
 
 def test_mol_weight_return_condition_indicators(smiles_light_mols, smiles_heavy_mols):
@@ -211,7 +212,7 @@ def test_mol_weight_return_condition_indicators(smiles_light_mols, smiles_heavy_
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 1)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 1))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -226,7 +227,7 @@ def test_mol_weight_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 1)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 1))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/oprea.py
+++ b/tests/filters/oprea.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import OpreaFilter
 
@@ -32,21 +33,21 @@ def test_mols_passing_oprea_filter(smiles_passing_oprea):
     mol_filter = OpreaFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_oprea)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_oprea)
+    assert_equal(len(smiles_filtered), len(smiles_passing_oprea))
 
 
 def test_mols_partially_passing_oprea_filter(smiles_passing_oprea_one_fail):
     mol_filter = OpreaFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_oprea_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_oprea_one_fail)
+    assert_equal(len(smiles_filtered), len(smiles_passing_oprea_one_fail))
 
 
 def test_mols_failing_oprea_filter(smiles_failing_oprea):
     mol_filter = OpreaFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_oprea)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_oprea_filter_return_indicators(
@@ -66,7 +67,7 @@ def test_oprea_filter_return_indicators(
         + [False] * len(smiles_passing_oprea_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = OpreaFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -76,7 +77,7 @@ def test_oprea_filter_return_indicators(
         + [True] * len(smiles_passing_oprea_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_oprea_filter_parallel(smiles_list):
@@ -86,7 +87,7 @@ def test_oprea_filter_parallel(smiles_list):
     mol_filter = OpreaFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_oprea_transform_x_y(smiles_passing_oprea, smiles_failing_oprea):
@@ -95,13 +96,13 @@ def test_oprea_transform_x_y(smiles_passing_oprea, smiles_failing_oprea):
 
     filt = OpreaFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_oprea)
+    assert_equal(len(mols), len(smiles_passing_oprea))
     assert np.all(labels_filt == 1)
 
     filt = OpreaFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_oprea)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_oprea))
+    assert_equal(indicators, labels_filt)
 
 
 def test_oprea_condition_names():
@@ -109,7 +110,7 @@ def test_oprea_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (4,)
+    assert_equal(condition_names.shape, (4,))
 
 
 def test_oprea_return_condition_indicators(smiles_passing_oprea, smiles_failing_oprea):
@@ -119,7 +120,7 @@ def test_oprea_return_condition_indicators(smiles_passing_oprea, smiles_failing_
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -134,7 +135,7 @@ def test_oprea_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/pfizer.py
+++ b/tests/filters/pfizer.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import PfizerFilter
 
@@ -31,32 +32,28 @@ def smiles_passing_one_violation_pfizer() -> list[str]:
     ]
 
 
-def test_mols_passing_pfizer(
-    smiles_passing_pfizer,
-):
+def test_mols_passing_pfizer(smiles_passing_pfizer):
     mol_filter = PfizerFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_pfizer)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_pfizer)
+    assert_equal(len(smiles_filtered), len(smiles_passing_pfizer))
 
 
 def test_mols_failing_pfizer(smiles_failing_pfizer):
     mol_filter = PfizerFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_pfizer)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
-def test_mols_passing_with_violation_pfizer(
-    smiles_passing_one_violation_pfizer,
-):
+def test_mols_passing_with_violation_pfizer(smiles_passing_one_violation_pfizer):
     mol_filter = PfizerFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_pfizer)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = PfizerFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_pfizer)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_pfizer_return_indicators(
@@ -78,7 +75,7 @@ def test_pfizer_return_indicators(
         + [False] * len(smiles_passing_one_violation_pfizer),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = PfizerFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -88,7 +85,7 @@ def test_pfizer_return_indicators(
         + [True] * len(smiles_passing_one_violation_pfizer),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_pfizer_parallel(smiles_list):
@@ -98,7 +95,7 @@ def test_pfizer_parallel(smiles_list):
     mol_filter = PfizerFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_pfizer_transform_x_y(smiles_passing_pfizer, smiles_failing_pfizer):
@@ -109,13 +106,13 @@ def test_pfizer_transform_x_y(smiles_passing_pfizer, smiles_failing_pfizer):
 
     filt = PfizerFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_pfizer)
+    assert_equal(len(mols), len(smiles_passing_pfizer))
     assert np.all(labels_filt == 1)
 
     filt = PfizerFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_pfizer)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_pfizer))
+    assert_equal(indicators, labels_filt)
 
 
 def test_pfizer_condition_names():
@@ -123,7 +120,7 @@ def test_pfizer_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (2,)
+    assert_equal(condition_names.shape, (2,))
 
 
 def test_pfizer_return_condition_indicators(
@@ -135,7 +132,7 @@ def test_pfizer_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -152,7 +149,7 @@ def test_pfizer_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/reos.py
+++ b/tests/filters/reos.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import REOSFilter
 
@@ -33,21 +34,21 @@ def test_mols_passing_reos(smiles_passing_reos):
     mol_filter = REOSFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_reos)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_reos)
+    assert_equal(len(smiles_filtered), len(smiles_passing_reos))
 
 
 def test_mols_partially_passing_reos(smiles_passing_one_fail):
     mol_filter = REOSFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_fail)
+    assert_equal(len(smiles_filtered), len(smiles_passing_one_fail))
 
 
 def test_mols_failing_reos(smiles_failing_reos):
     mol_filter = REOSFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_reos)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_reos_filter_return_indicators(
@@ -65,7 +66,7 @@ def test_reos_filter_return_indicators(
         + [False] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = REOSFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -75,7 +76,7 @@ def test_reos_filter_return_indicators(
         + [True] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_reos_filter_parallel(smiles_list):
@@ -85,7 +86,7 @@ def test_reos_filter_parallel(smiles_list):
     mol_filter = REOSFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_reos_transform_x_y(smiles_passing_reos, smiles_failing_reos):
@@ -94,13 +95,13 @@ def test_reos_transform_x_y(smiles_passing_reos, smiles_failing_reos):
 
     filt = REOSFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_reos)
+    assert_equal(len(mols), len(smiles_passing_reos))
     assert np.all(labels_filt == 1)
 
     filt = REOSFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_reos)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_reos))
+    assert_equal(indicators, labels_filt)
 
 
 def test_reos_condition_names():
@@ -108,7 +109,7 @@ def test_reos_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (7,)
+    assert_equal(condition_names.shape, (7,))
 
 
 def test_reos_return_condition_indicators(smiles_passing_reos, smiles_failing_reos):
@@ -118,7 +119,7 @@ def test_reos_return_condition_indicators(smiles_passing_reos, smiles_failing_re
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 7)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 7))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -133,7 +134,7 @@ def test_reos_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 7)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 7))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/rule_of_four.py
+++ b/tests/filters/rule_of_four.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import RuleOfFourFilter
 
@@ -31,20 +32,18 @@ def smiles_passing_one_violation_rule_of_four() -> list[str]:
     ]
 
 
-def test_mols_passing_rule_of_four(
-    smiles_passing_rule_of_four,
-):
+def test_mols_passing_rule_of_four(smiles_passing_rule_of_four):
     mol_filter = RuleOfFourFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_four)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_rule_of_four)
+    assert_equal(len(smiles_filtered), len(smiles_passing_rule_of_four))
 
 
 def test_mols_failing_rule_of_four(smiles_failing_rule_of_four):
     mol_filter = RuleOfFourFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_four)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_rule_of_four(
@@ -52,11 +51,11 @@ def test_mols_passing_with_violation_rule_of_four(
 ):
     mol_filter = RuleOfFourFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_four)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = RuleOfFourFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_four)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_rule_of_four_return_indicators(
@@ -78,7 +77,7 @@ def test_rule_of_four_return_indicators(
         + [False] * len(smiles_passing_one_violation_rule_of_four),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfFourFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -88,7 +87,7 @@ def test_rule_of_four_return_indicators(
         + [True] * len(smiles_passing_one_violation_rule_of_four),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_rule_of_four_parallel(smiles_list):
@@ -98,7 +97,7 @@ def test_rule_of_four_parallel(smiles_list):
     mol_filter = RuleOfFourFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_rule_of_four_transform_x_y(
@@ -111,13 +110,13 @@ def test_rule_of_four_transform_x_y(
 
     filt = RuleOfFourFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_rule_of_four)
+    assert_equal(len(mols), len(smiles_passing_rule_of_four))
     assert np.all(labels_filt == 1)
 
     filt = RuleOfFourFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_rule_of_four)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_rule_of_four))
+    assert_equal(indicators, labels_filt)
 
 
 def test_rule_of_four_condition_names():
@@ -125,7 +124,7 @@ def test_rule_of_four_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (4,)
+    assert_equal(condition_names.shape, (4,))
 
 
 def test_rule_of_four_return_condition_indicators(
@@ -137,7 +136,7 @@ def test_rule_of_four_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -154,7 +153,7 @@ def test_rule_of_four_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/rule_of_three.py
+++ b/tests/filters/rule_of_three.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import RuleOfThreeFilter
 
@@ -54,28 +55,28 @@ def test_mols_passing_basic_rule_of_three(smiles_passing_basic_rule_of_three):
     mol_filter = RuleOfThreeFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_basic_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_basic_rule_of_three)
+    assert_equal(len(smiles_filtered), len(smiles_passing_basic_rule_of_three))
 
 
 def test_mols_passing_extended_rule_of_three(smiles_passing_extended_rule_of_three):
     mol_filter = RuleOfThreeFilter(extended=True)
     smiles_filtered = mol_filter.transform(smiles_passing_extended_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_extended_rule_of_three)
+    assert_equal(len(smiles_filtered), len(smiles_passing_extended_rule_of_three))
 
 
 def test_mols_failing_basic_rule_of_three(smiles_failing_basic_rule_of_three):
     mol_filter = RuleOfThreeFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_basic_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_failing_basic_rule_of_three)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_failing_extended_rule_of_three(smiles_failing_extended_rule_of_three):
     mol_filter = RuleOfThreeFilter(extended=True)
     smiles_filtered = mol_filter.transform(smiles_failing_extended_rule_of_three)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_basic_rule_of_three(
@@ -85,13 +86,13 @@ def test_mols_passing_with_violation_basic_rule_of_three(
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_basic_rule_of_three
     )
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = RuleOfThreeFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_basic_rule_of_three
     )
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_extended_rule_of_three(
@@ -101,13 +102,13 @@ def test_mols_passing_with_violation_extended_rule_of_three(
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_extended_rule_of_three
     )
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = RuleOfThreeFilter(allow_one_violation=False, extended=True)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_extended_rule_of_three
     )
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_rule_of_three_return_indicators(
@@ -129,7 +130,7 @@ def test_rule_of_three_return_indicators(
         + [False] * len(smiles_passing_one_violation_extended_rule_of_three),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfThreeFilter(
         extended=True, allow_one_violation=True, return_type="indicators"
@@ -141,7 +142,7 @@ def test_rule_of_three_return_indicators(
         + [True] * len(smiles_passing_one_violation_extended_rule_of_three),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_rule_of_three_parallel(smiles_list):
@@ -151,7 +152,7 @@ def test_rule_of_three_parallel(smiles_list):
     mol_filter = RuleOfThreeFilter(extended=True, n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_rule_of_three_transform_x_y(
@@ -165,13 +166,13 @@ def test_rule_of_three_transform_x_y(
 
     filt = RuleOfThreeFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_basic_rule_of_three)
+    assert_equal(len(mols), len(smiles_passing_basic_rule_of_three))
     assert np.all(labels_filt == 1)
 
     filt = RuleOfThreeFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_basic_rule_of_three)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_basic_rule_of_three))
+    assert_equal(indicators, labels_filt)
 
 
 @pytest.mark.parametrize(
@@ -185,7 +186,7 @@ def test_rule_of_three_condition_names(filt, num_conditions):
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (num_conditions,)
+    assert_equal(condition_names.shape, (num_conditions,))
 
 
 def test_basic_rule_of_three_return_condition_indicators(
@@ -197,7 +198,7 @@ def test_basic_rule_of_three_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -213,7 +214,7 @@ def test_extended_rule_of_three_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -231,10 +232,10 @@ def test_basic_rule_of_three_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))
 
 
 def test_extended_rule_of_three_return_condition_indicators_transform_x_y(
@@ -252,7 +253,7 @@ def test_extended_rule_of_three_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 6)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 6))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/rule_of_two.py
+++ b/tests/filters/rule_of_two.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import RuleOfTwoFilter
 
@@ -27,14 +28,14 @@ def test_mols_passing_rule_of_two(smiles_passing_rule_of_two):
     mol_filter = RuleOfTwoFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_two)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_rule_of_two)
+    assert_equal(len(smiles_filtered), len(smiles_passing_rule_of_two))
 
 
 def test_mols_failing_rule_of_two(smiles_failing_rule_of_two):
     mol_filter = RuleOfTwoFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_two)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_rule_of_two(
@@ -42,11 +43,11 @@ def test_mols_passing_with_violation_rule_of_two(
 ):
     mol_filter = RuleOfTwoFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_two)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = RuleOfTwoFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_rule_of_two)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_rule_of_two_return_indicators(
@@ -68,7 +69,7 @@ def test_rule_of_two_return_indicators(
         + [False] * len(smiles_passing_one_violation_rule_of_two),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfTwoFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -78,7 +79,7 @@ def test_rule_of_two_return_indicators(
         + [True] * len(smiles_passing_one_violation_rule_of_two),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_rule_of_two_parallel(smiles_list):
@@ -88,7 +89,7 @@ def test_rule_of_two_parallel(smiles_list):
     mol_filter = RuleOfTwoFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_rule_of_two_transform_x_y(
@@ -101,13 +102,13 @@ def test_rule_of_two_transform_x_y(
 
     filt = RuleOfTwoFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_rule_of_two)
+    assert_equal(len(mols), len(smiles_passing_rule_of_two))
     assert np.all(labels_filt == 1)
 
     filt = RuleOfTwoFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_rule_of_two)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_rule_of_two))
+    assert_equal(indicators, labels_filt)
 
 
 def test_rule_of_two_condition_names():
@@ -115,7 +116,7 @@ def test_rule_of_two_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (4,)
+    assert_equal(condition_names.shape, (4,))
 
 
 def test_rule_of_two_return_condition_indicators(
@@ -127,7 +128,7 @@ def test_rule_of_two_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -144,7 +145,7 @@ def test_rule_of_two_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 4)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 4))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/rule_of_veber.py
+++ b/tests/filters/rule_of_veber.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import RuleOfVeberFilter
 
@@ -29,21 +30,21 @@ def test_mols_passing_rule_of_veber(smiles_passing_rule_of_veber):
     mol_filter = RuleOfVeberFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_veber)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_rule_of_veber)
+    assert_equal(len(smiles_filtered), len(smiles_passing_rule_of_veber))
 
 
 def test_mols_partially_passing_rule_of_veber(smiles_passing_one_fail):
     mol_filter = RuleOfVeberFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_fail)
+    assert_equal(len(smiles_filtered), len(smiles_passing_one_fail))
 
 
 def test_mols_failing_rule_of_veber(smiles_failing_rule_of_veber):
     mol_filter = RuleOfVeberFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_veber)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_rule_of_veber_return_indicators(
@@ -65,7 +66,7 @@ def test_rule_of_veber_return_indicators(
         + [False] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfVeberFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -75,7 +76,7 @@ def test_rule_of_veber_return_indicators(
         + [True] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_rule_of_veber_parallel(smiles_list):
@@ -85,7 +86,7 @@ def test_rule_of_veber_parallel(smiles_list):
     mol_filter = RuleOfVeberFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_rule_of_veber_transform_x_y(
@@ -99,13 +100,13 @@ def test_rule_of_veber_transform_x_y(
 
     filt = RuleOfVeberFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_rule_of_veber)
+    assert_equal(len(mols), len(smiles_passing_rule_of_veber))
     assert np.all(labels_filt == 1)
 
     filt = RuleOfVeberFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_rule_of_veber)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_rule_of_veber))
+    assert_equal(indicators, labels_filt)
 
 
 def test_rule_of_veber_condition_names():
@@ -113,7 +114,7 @@ def test_rule_of_veber_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (2,)
+    assert_equal(condition_names.shape, (2,))
 
 
 def test_rule_of_veber_return_condition_indicators(
@@ -125,7 +126,7 @@ def test_rule_of_veber_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -143,7 +144,7 @@ def test_rule_of_veber_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 2)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 2))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/rule_of_xu.py
+++ b/tests/filters/rule_of_xu.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import RuleOfXuFilter
 
@@ -33,21 +34,21 @@ def test_mols_passing_rule_of_xu(smiles_passing_rule_of_xu):
     mol_filter = RuleOfXuFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_rule_of_xu)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_rule_of_xu)
+    assert_equal(len(smiles_filtered), len(smiles_passing_rule_of_xu))
 
 
 def test_mols_partially_passing_rule_of_xu(smiles_passing_one_fail):
     mol_filter = RuleOfXuFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_fail)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_fail)
+    assert_equal(len(smiles_filtered), len(smiles_passing_one_fail))
 
 
 def test_mols_failing_rule_of_xu(smiles_failing_rule_of_xu):
     mol_filter = RuleOfXuFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_rule_of_xu)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_rule_of_xu_return_indicators(
@@ -67,7 +68,7 @@ def test_rule_of_xu_return_indicators(
         + [False] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = RuleOfXuFilter(allow_one_violation=True, return_type="indicators")
     filter_indicators = mol_filter.transform(all_smiles)
@@ -77,7 +78,7 @@ def test_rule_of_xu_return_indicators(
         + [True] * len(smiles_passing_one_fail),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_rule_of_xu_parallel(smiles_list):
@@ -87,7 +88,7 @@ def test_rule_of_xu_parallel(smiles_list):
     mol_filter = RuleOfXuFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_rule_of_xu_transform_x_y(smiles_passing_rule_of_xu, smiles_failing_rule_of_xu):
@@ -98,13 +99,13 @@ def test_rule_of_xu_transform_x_y(smiles_passing_rule_of_xu, smiles_failing_rule
 
     filt = RuleOfXuFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_rule_of_xu)
+    assert_equal(len(mols), len(smiles_passing_rule_of_xu))
     assert np.all(labels_filt == 1)
 
     filt = RuleOfXuFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_rule_of_xu)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_rule_of_xu))
+    assert_equal(indicators, labels_filt)
 
 
 def test_rule_of_xu_condition_names():
@@ -112,7 +113,7 @@ def test_rule_of_xu_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (5,)
+    assert_equal(condition_names.shape, (5,))
 
 
 def test_rule_of_xu_return_condition_indicators(
@@ -124,7 +125,7 @@ def test_rule_of_xu_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -141,7 +142,7 @@ def test_rule_of_xu_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/substructural_filters.py
+++ b/tests/filters/substructural_filters.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.filters import (
@@ -65,7 +66,7 @@ def test_substructural_filter_parallel(substruct_filt_cls, smiles_list):
     filt = substruct_filt_cls(n_jobs=-1)
     smiles_filtered_parallel = filt.transform(smiles_list)
 
-    assert smiles_filtered_sequential == smiles_filtered_parallel
+    assert_equal(smiles_filtered_sequential, smiles_filtered_parallel)
 
 
 @pytest.mark.parametrize("substruct_filt_cls", _get_substructural_filter_classes())
@@ -85,7 +86,7 @@ def test_substructural_filter_return_indicators(substruct_filt_cls, mols_list):
     filt = substruct_filt_cls(return_type="indicators")
     filter_indicators = filt.transform(mols_list)
 
-    assert len(filter_indicators) == len(mols_list)
+    assert_equal(len(filter_indicators), len(mols_list))
     assert isinstance(filter_indicators, np.ndarray)
     assert np.issubdtype(filter_indicators.dtype, bool)
     assert np.all(np.isin(filter_indicators, [0, 1]))
@@ -97,7 +98,7 @@ def test_substructural_filter_transform_x_y(substruct_filt_cls, mols_list):
 
     filt = substruct_filt_cls()
     mols_filtered, labels_filt = filt.transform_x_y(mols_list, labels)
-    assert len(mols_filtered) == len(labels_filt)
+    assert_equal(len(mols_filtered), len(labels_filt))
 
 
 @pytest.mark.parametrize(
@@ -111,7 +112,7 @@ def test_substructural_filter_condition_names(
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (expected_num_conditions,)
+    assert_equal(condition_names.shape, (expected_num_conditions,))
 
 
 @pytest.mark.parametrize(
@@ -125,7 +126,7 @@ def test_substructural_filter_return_condition_indicators(
     condition_indicators = filt.transform(mols_list)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(mols_list), expected_num_conditions)
+    assert_equal(condition_indicators.shape, (len(mols_list), expected_num_conditions))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -143,7 +144,7 @@ def test_substructural_filter_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(mols_list, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(mols_list), expected_num_conditions)
+    assert_equal(condition_indicators.shape, (len(mols_list), expected_num_conditions))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/tice_herbicides.py
+++ b/tests/filters/tice_herbicides.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import TiceHerbicidesFilter
 
@@ -31,20 +32,18 @@ def smiles_passing_one_violation_tice_herbicides() -> list[str]:
     ]
 
 
-def test_mols_passing_tice_herbicides(
-    smiles_passing_tice_herbicides,
-):
+def test_mols_passing_tice_herbicides(smiles_passing_tice_herbicides):
     mol_filter = TiceHerbicidesFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_tice_herbicides)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_tice_herbicides)
+    assert_equal(len(smiles_filtered), len(smiles_passing_tice_herbicides))
 
 
 def test_mols_failing_tice_herbicides(smiles_failing_tice_herbicides):
     mol_filter = TiceHerbicidesFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_tice_herbicides)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_tice_herbicides(
@@ -52,11 +51,11 @@ def test_mols_passing_with_violation_tice_herbicides(
 ):
     mol_filter = TiceHerbicidesFilter(allow_one_violation=True)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_tice_herbicides)
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = TiceHerbicidesFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(smiles_passing_one_violation_tice_herbicides)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_tice_herbicides_return_indicators(
@@ -78,7 +77,7 @@ def test_tice_herbicides_return_indicators(
         + [False] * len(smiles_passing_one_violation_tice_herbicides),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = TiceHerbicidesFilter(
         allow_one_violation=True, return_type="indicators"
@@ -90,7 +89,7 @@ def test_tice_herbicides_return_indicators(
         + [True] * len(smiles_passing_one_violation_tice_herbicides),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_tice_herbicides_parallel(smiles_list):
@@ -100,7 +99,7 @@ def test_tice_herbicides_parallel(smiles_list):
     mol_filter = TiceHerbicidesFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_tice_herbicides_transform_x_y(
@@ -114,13 +113,13 @@ def test_tice_herbicides_transform_x_y(
 
     filt = TiceHerbicidesFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_tice_herbicides)
+    assert_equal(len(mols), len(smiles_passing_tice_herbicides))
     assert np.all(labels_filt == 1)
 
     filt = TiceHerbicidesFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_tice_herbicides)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_tice_herbicides))
+    assert_equal(indicators, labels_filt)
 
 
 def test_tice_herbicides_condition_names():
@@ -128,7 +127,7 @@ def test_tice_herbicides_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (5,)
+    assert_equal(condition_names.shape, (5,))
 
 
 def test_tice_herbicides_return_condition_indicators(
@@ -140,7 +139,7 @@ def test_tice_herbicides_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -158,7 +157,7 @@ def test_tice_herbicides_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/tice_insecticides.py
+++ b/tests/filters/tice_insecticides.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import TiceInsecticidesFilter
 
@@ -31,20 +32,18 @@ def smiles_passing_one_violation_tice_insecticides() -> list[str]:
     ]
 
 
-def test_mols_passing_tice_insecticides(
-    smiles_passing_tice_insecticides,
-):
+def test_mols_passing_tice_insecticides(smiles_passing_tice_insecticides):
     mol_filter = TiceInsecticidesFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_tice_insecticides)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_tice_insecticides)
+    assert_equal(len(smiles_filtered), len(smiles_passing_tice_insecticides))
 
 
 def test_mols_failing_tice_insecticides(smiles_failing_tice_insecticides):
     mol_filter = TiceInsecticidesFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_tice_insecticides)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_mols_passing_with_violation_tice_insecticides(
@@ -54,13 +53,13 @@ def test_mols_passing_with_violation_tice_insecticides(
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_tice_insecticides
     )
-    assert len(smiles_filtered) == 3
+    assert_equal(len(smiles_filtered), 3)
 
     mol_filter = TiceInsecticidesFilter(allow_one_violation=False)
     smiles_filtered = mol_filter.transform(
         smiles_passing_one_violation_tice_insecticides
     )
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_tice_insecticides_return_indicators(
@@ -82,7 +81,7 @@ def test_tice_insecticides_return_indicators(
         + [False] * len(smiles_passing_one_violation_tice_insecticides),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = TiceInsecticidesFilter(
         allow_one_violation=True, return_type="indicators"
@@ -94,7 +93,7 @@ def test_tice_insecticides_return_indicators(
         + [True] * len(smiles_passing_one_violation_tice_insecticides),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_tice_insecticides_parallel(smiles_list):
@@ -104,7 +103,7 @@ def test_tice_insecticides_parallel(smiles_list):
     mol_filter = TiceInsecticidesFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_tice_insecticides_transform_x_y(
@@ -118,13 +117,13 @@ def test_tice_insecticides_transform_x_y(
 
     filt = TiceInsecticidesFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_tice_insecticides)
+    assert_equal(len(mols), len(smiles_passing_tice_insecticides))
     assert np.all(labels_filt == 1)
 
     filt = TiceInsecticidesFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_tice_insecticides)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_tice_insecticides))
+    assert_equal(indicators, labels_filt)
 
 
 def test_tice_insecticides_condition_names():
@@ -132,7 +131,7 @@ def test_tice_insecticides_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (5,)
+    assert_equal(condition_names.shape, (5,))
 
 
 def test_tice_insecticides_return_condition_indicators(
@@ -144,7 +143,7 @@ def test_tice_insecticides_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -162,7 +161,7 @@ def test_tice_insecticides_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 5)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 5))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/utils.py
+++ b/tests/filters/utils.py
@@ -1,5 +1,5 @@
-import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import Mol, MolFromSmiles
 
 from skfp.filters.utils import (
@@ -19,65 +19,65 @@ def ibuprofen() -> Mol:
 
 
 def test_get_num_carbon_atoms(ibuprofen):
-    assert get_num_carbon_atoms(ibuprofen) == 13
+    assert_equal(get_num_carbon_atoms(ibuprofen), 13)
 
 
 def test_get_num_rigid_bonds(ibuprofen):
-    assert get_num_rigid_bonds(ibuprofen) == 11
+    assert_equal(get_num_rigid_bonds(ibuprofen), 11)
 
 
 def test_get_num_aromatic_rings():
     # tetrahydrothiophene
     mol = MolFromSmiles("S1CCCC1")
-    assert get_num_aromatic_rings(mol) == 0
+    assert_equal(get_num_aromatic_rings(mol), 0)
 
     # benzene
     mol = MolFromSmiles("c1ccccc1")
-    assert get_num_aromatic_rings(mol) == 1
+    assert_equal(get_num_aromatic_rings(mol), 1)
 
     # naphthalene
     mol = MolFromSmiles("c1c2ccccc2ccc1")
-    assert get_num_aromatic_rings(mol) == 2
+    assert_equal(get_num_aromatic_rings(mol), 2)
 
     # pyrene
     mol = MolFromSmiles("c1cc2cccc3c2c4c1cccc4cc3")
-    assert get_num_aromatic_rings(mol) == 4
+    assert_equal(get_num_aromatic_rings(mol), 4)
 
     # chlordiazepoxide
     mol = MolFromSmiles("ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1")
-    assert get_num_aromatic_rings(mol) == 2
+    assert_equal(get_num_aromatic_rings(mol), 2)
 
 
 def test_get_max_num_fused_aromatic_rings():
     # tetrahydrothiophene
     mol = MolFromSmiles("S1CCCC1")
-    assert get_max_num_fused_aromatic_rings(mol) == 0
+    assert_equal(get_max_num_fused_aromatic_rings(mol), 0)
 
     # benzene
     mol = MolFromSmiles("c1ccccc1")
-    assert get_max_num_fused_aromatic_rings(mol) == 0
+    assert_equal(get_max_num_fused_aromatic_rings(mol), 0)
 
     # naphthalene
     mol = MolFromSmiles("c1c2ccccc2ccc1")
-    assert get_max_num_fused_aromatic_rings(mol) == 2
+    assert_equal(get_max_num_fused_aromatic_rings(mol), 2)
 
     # pyrene
     mol = MolFromSmiles("c1cc2cccc3c2c4c1cccc4cc3")
-    assert get_max_num_fused_aromatic_rings(mol) == 4
+    assert_equal(get_max_num_fused_aromatic_rings(mol), 4)
 
     # chlordiazepoxide
     mol = MolFromSmiles("ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1")
-    assert get_max_num_fused_aromatic_rings(mol) == 0
+    assert_equal(get_max_num_fused_aromatic_rings(mol), 0)
 
 
 def test_get_max_ring_size(ibuprofen):
-    assert get_max_ring_size(ibuprofen) == 6
+    assert_equal(get_max_ring_size(ibuprofen), 6)
 
 
 def test_get_non_carbon_to_carbon_ratio():
     # phenol
     mol = MolFromSmiles("Oc1ccccc1")
-    assert np.isclose(get_non_carbon_to_carbon_ratio(mol), 1 / 6)
+    assert_allclose(get_non_carbon_to_carbon_ratio(mol), 1 / 6)
 
 
 def test_get_num_charged_functional_groups(mols_list):

--- a/tests/filters/valence_discovery.py
+++ b/tests/filters/valence_discovery.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.filters import ValenceDiscoveryFilter
 
@@ -42,7 +43,7 @@ def test_mols_passing_valence_discovery(smiles_passing_valence_discovery):
     mol_filter = ValenceDiscoveryFilter()
     smiles_filtered = mol_filter.transform(smiles_passing_valence_discovery)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_valence_discovery)
+    assert_equal(len(smiles_filtered), len(smiles_passing_valence_discovery))
 
 
 def test_mols_partially_passing_valence_discovery(
@@ -53,14 +54,16 @@ def test_mols_partially_passing_valence_discovery(
         smiles_passing_one_violation_valence_discovery
     )
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == len(smiles_passing_one_violation_valence_discovery)
+    assert_equal(
+        len(smiles_filtered), len(smiles_passing_one_violation_valence_discovery)
+    )
 
 
 def test_mols_failing_valence_discovery(smiles_failing_valence_discovery):
     mol_filter = ValenceDiscoveryFilter()
     smiles_filtered = mol_filter.transform(smiles_failing_valence_discovery)
     assert all(isinstance(x, str) for x in smiles_filtered)
-    assert len(smiles_filtered) == 0
+    assert_equal(len(smiles_filtered), 0)
 
 
 def test_valence_discovery_return_indicators(
@@ -82,7 +85,7 @@ def test_valence_discovery_return_indicators(
         + [False] * len(smiles_passing_one_violation_valence_discovery),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
     mol_filter = ValenceDiscoveryFilter(
         allow_one_violation=True, return_type="indicators"
@@ -94,7 +97,7 @@ def test_valence_discovery_return_indicators(
         + [True] * len(smiles_passing_one_violation_valence_discovery),
         dtype=bool,
     )
-    assert np.array_equal(filter_indicators, expected_indicators)
+    assert_equal(filter_indicators, expected_indicators)
 
 
 def test_valence_discovery_parallel(smiles_list):
@@ -104,7 +107,7 @@ def test_valence_discovery_parallel(smiles_list):
     mol_filter = ValenceDiscoveryFilter(n_jobs=-1, batch_size=1)
     mols_filtered_parallel = mol_filter.transform(smiles_list)
 
-    assert mols_filtered_sequential == mols_filtered_parallel
+    assert_equal(mols_filtered_sequential, mols_filtered_parallel)
 
 
 def test_valence_discovery_transform_x_y(
@@ -118,13 +121,13 @@ def test_valence_discovery_transform_x_y(
 
     filt = ValenceDiscoveryFilter()
     mols, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert len(mols) == len(smiles_passing_valence_discovery)
+    assert_equal(len(mols), len(smiles_passing_valence_discovery))
     assert np.all(labels_filt == 1)
 
     filt = ValenceDiscoveryFilter(return_type="indicators")
     indicators, labels_filt = filt.transform_x_y(all_smiles, labels)
-    assert np.sum(indicators) == len(smiles_passing_valence_discovery)
-    assert np.array_equal(indicators, labels_filt)
+    assert_equal(np.sum(indicators), len(smiles_passing_valence_discovery))
+    assert_equal(indicators, labels_filt)
 
 
 def test_valence_discovery_condition_names():
@@ -132,7 +135,7 @@ def test_valence_discovery_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (16,)
+    assert_equal(condition_names.shape, (16,))
 
 
 def test_valence_discovery_return_condition_indicators(
@@ -144,7 +147,7 @@ def test_valence_discovery_return_condition_indicators(
     condition_indicators = filt.transform(all_smiles)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 16)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 16))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -162,7 +165,7 @@ def test_valence_discovery_return_condition_indicators_transform_x_y(
     condition_indicators, y = filt.transform_x_y(all_smiles, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(all_smiles), 16)
+    assert_equal(condition_indicators.shape, (len(all_smiles), 16))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/filters/zinc_druglike.py
+++ b/tests/filters/zinc_druglike.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.filters import ZINCDruglikeFilter
@@ -8,7 +9,7 @@ def test_zinc_druglike(mols_list):
     pains = ZINCDruglikeFilter()
     mols_filtered = pains.transform(mols_list)
     assert all(isinstance(x, Mol) for x in mols_filtered)
-    assert len(mols_filtered) <= len(mols_list)
+    assert_equal(len(mols_filtered) <= len(mols_list), True)
 
 
 def test_zinc_druglike_parallel(smiles_list):
@@ -18,7 +19,7 @@ def test_zinc_druglike_parallel(smiles_list):
     filt = ZINCDruglikeFilter(n_jobs=-1)
     smiles_filtered_parallel = filt.transform(smiles_list)
 
-    assert smiles_filtered_sequential == smiles_filtered_parallel
+    assert_equal(smiles_filtered_sequential, smiles_filtered_parallel)
 
 
 def test_zinc_druglike_allowing_one_violation(mols_list):
@@ -28,8 +29,8 @@ def test_zinc_druglike_allowing_one_violation(mols_list):
     mols_filtered = filt.transform(mols_list)
     mols_filtered_loose = filt_loose.transform(mols_list)
 
-    assert len(mols_filtered) <= len(mols_filtered_loose)
-    assert len(mols_filtered_loose) <= len(mols_list)
+    assert_equal(len(mols_filtered) <= len(mols_filtered_loose), True)
+    assert_equal(len(mols_filtered_loose) <= len(mols_list), True)
 
 
 def test_zinc_druglike_transform_x_y(mols_list):
@@ -37,7 +38,7 @@ def test_zinc_druglike_transform_x_y(mols_list):
 
     filt = ZINCDruglikeFilter()
     mols_filtered, labels_filt = filt.transform_x_y(mols_list, labels)
-    assert len(mols_filtered) == len(labels_filt)
+    assert_equal(len(mols_filtered), len(labels_filt))
 
 
 def test_zinc_druglike_condition_names():
@@ -45,7 +46,7 @@ def test_zinc_druglike_condition_names():
     condition_names = filt.get_feature_names_out()
 
     assert isinstance(condition_names, np.ndarray)
-    assert condition_names.shape == (13,)
+    assert_equal(condition_names.shape, (13,))
 
 
 def test_zinc_druglike_return_condition_indicators(mols_list):
@@ -53,7 +54,7 @@ def test_zinc_druglike_return_condition_indicators(mols_list):
     condition_indicators = filt.transform(mols_list)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(mols_list), 13)
+    assert_equal(condition_indicators.shape, (len(mols_list), 13))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
 
@@ -65,7 +66,7 @@ def test_zinc_druglike_return_condition_indicators_transform_x_y(mols_list):
     condition_indicators, y = filt.transform_x_y(mols_list, labels)
 
     assert isinstance(condition_indicators, np.ndarray)
-    assert condition_indicators.shape == (len(mols_list), 13)
+    assert_equal(condition_indicators.shape, (len(mols_list), 13))
     assert np.issubdtype(condition_indicators.dtype, bool)
     assert np.all(np.isin(condition_indicators, [0, 1]))
-    assert len(condition_indicators) == len(y)
+    assert_equal(len(condition_indicators), len(y))

--- a/tests/fingerprints/atom_pair.py
+++ b/tests/fingerprints/atom_pair.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdFingerprintGenerator import (
     GetAtomPairGenerator,
     GetMorganFeatureAtomInvGen,
@@ -17,8 +18,8 @@ def test_atom_pair_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetAtomPairGenerator()
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -35,8 +36,8 @@ def test_atom_pair_bit_3D_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -48,8 +49,8 @@ def test_atom_pair_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetAtomPairGenerator()
     X_rdkit = np.array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -66,8 +67,8 @@ def test_atom_pair_count_3D_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -79,8 +80,8 @@ def test_atom_pair_sparse_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetAtomPairGenerator()
     X_rdkit = csr_array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -97,8 +98,8 @@ def test_atom_pair_sparse_3D_bit_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_conformers_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -110,8 +111,8 @@ def test_atom_pair_sparse_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetAtomPairGenerator()
     X_rdkit = csr_array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -128,8 +129,8 @@ def test_atom_pair_sparse_3D_count_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_conformers_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), atom_pair_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -141,8 +142,8 @@ def test_pharmacophoric_invariants(smiles_list, mols_list):
     fp_gen = GetAtomPairGenerator(atomInvariantsGenerator=GetMorganFeatureAtomInvGen())
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), pharma_ap_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), pharma_ap_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -158,9 +159,9 @@ def test_atom_pair_hac_scaling(smiles_list, mols_list):
         for fp, mol in zip(X_rdkit, mols_list, strict=False)
     ]
 
-    np.testing.assert_allclose(X_skfp, X_rdkit_scaled)
+    assert_allclose(X_skfp, X_rdkit_scaled)
     assert np.issubdtype(X_skfp.dtype, np.floating)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
 
 
 def test_atom_pair_squared_hac_scaling(smiles_list, mols_list):
@@ -174,10 +175,10 @@ def test_atom_pair_squared_hac_scaling(smiles_list, mols_list):
         for fp, mol in zip(X_rdkit, mols_list, strict=False)
     ]
 
-    np.testing.assert_allclose(X_skfp, X_rdkit_scaled)
+    assert_allclose(X_skfp, X_rdkit_scaled)
     assert np.all((X_skfp >= 0) & (X_skfp <= 100))
     assert np.issubdtype(X_skfp.dtype, np.floating)
-    assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), atom_pair_fp.fp_size))
 
 
 def test_hac_scaling_empty_mol():

--- a/tests/fingerprints/atom_pair.py
+++ b/tests/fingerprints/atom_pair.py
@@ -158,7 +158,7 @@ def test_atom_pair_hac_scaling(smiles_list, mols_list):
         for fp, mol in zip(X_rdkit, mols_list, strict=False)
     ]
 
-    assert np.allclose(X_skfp, X_rdkit_scaled)
+    np.testing.assert_allclose(X_skfp, X_rdkit_scaled)
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)
 
@@ -174,7 +174,7 @@ def test_atom_pair_squared_hac_scaling(smiles_list, mols_list):
         for fp, mol in zip(X_rdkit, mols_list, strict=False)
     ]
 
-    assert np.allclose(X_skfp, X_rdkit_scaled)
+    np.testing.assert_allclose(X_skfp, X_rdkit_scaled)
     assert np.all((X_skfp >= 0) & (X_skfp <= 100))
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert X_skfp.shape == (len(smiles_list), atom_pair_fp.fp_size)

--- a/tests/fingerprints/autocorr.py
+++ b/tests/fingerprints/autocorr.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import CalcAUTOCORR2D, CalcAUTOCORR3D
 
 from skfp.fingerprints import AutocorrFingerprint
@@ -9,8 +10,8 @@ def test_autocorr_fingerprint(smiles_list, mols_list):
     X_skfp = autocorr_fp.transform(smiles_list)
     X_rdkit = np.array([CalcAUTOCORR2D(mol) for mol in mols_list])
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 192)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 192))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -25,8 +26,8 @@ def test_autocorr_3D_fingerprint(mols_conformers_list):
         ]
     )
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), 80)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 80))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -34,26 +35,26 @@ def test_autocorr_feature_names():
     autocorr_fp = AutocorrFingerprint()
     feature_names = autocorr_fp.get_feature_names_out()
 
-    assert len(feature_names) == autocorr_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), autocorr_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "Moreau-Broto mass distance 0"
-    assert feature_names[1] == "Moreau-Broto mass distance 1"
-    assert feature_names[8] == "Moreau-Broto van der Waals volume distance 0"
-    assert feature_names[48] == "Centered Moreau-Broto mass distance 0"
-    assert feature_names[-2] == "Geary IState distance 6"
-    assert feature_names[-1] == "Geary IState distance 7"
+    assert_equal(feature_names[0], "Moreau-Broto mass distance 0")
+    assert_equal(feature_names[1], "Moreau-Broto mass distance 1")
+    assert_equal(feature_names[8], "Moreau-Broto van der Waals volume distance 0")
+    assert_equal(feature_names[48], "Centered Moreau-Broto mass distance 0")
+    assert_equal(feature_names[-2], "Geary IState distance 6")
+    assert_equal(feature_names[-1], "Geary IState distance 7")
 
 
 def test_autocorr_3D_feature_names():
     autocorr_fp = AutocorrFingerprint(use_3D=True)
     feature_names = autocorr_fp.get_feature_names_out()
 
-    assert len(feature_names) == autocorr_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), autocorr_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "Moreau-Broto unweighted distance 0"
-    assert feature_names[1] == "Moreau-Broto unweighted distance 1"
-    assert feature_names[10] == "Moreau-Broto mass distance 0"
-    assert feature_names[-2] == "Moreau-Broto covalent radius distance 8"
-    assert feature_names[-1] == "Moreau-Broto covalent radius distance 9"
+    assert_equal(feature_names[0], "Moreau-Broto unweighted distance 0")
+    assert_equal(feature_names[1], "Moreau-Broto unweighted distance 1")
+    assert_equal(feature_names[10], "Moreau-Broto mass distance 0")
+    assert_equal(feature_names[-2], "Moreau-Broto covalent radius distance 8")
+    assert_equal(feature_names[-1], "Moreau-Broto covalent radius distance 9")

--- a/tests/fingerprints/autocorr.py
+++ b/tests/fingerprints/autocorr.py
@@ -9,7 +9,7 @@ def test_autocorr_fingerprint(smiles_list, mols_list):
     X_skfp = autocorr_fp.transform(smiles_list)
     X_rdkit = np.array([CalcAUTOCORR2D(mol) for mol in mols_list])
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(smiles_list), 192)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -25,7 +25,7 @@ def test_autocorr_3D_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(mols_conformers_list), 80)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/avalon.py
+++ b/tests/fingerprints/avalon.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
 from scipy.sparse import csr_array
 
@@ -10,8 +11,8 @@ def test_avalon_bit_fingerprint(smiles_list, mols_list):
     X_skfp = avalon_fp.transform(smiles_list)
     X_rdkit = np.array([GetAvalonFP(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), avalon_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), avalon_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -21,8 +22,8 @@ def test_avalon_count_fingerprint(smiles_list, mols_list):
     X_skfp = avalon_fp.transform(smiles_list)
     X_rdkit = np.array([GetAvalonCountFP(mol).ToList() for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), avalon_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), avalon_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -32,8 +33,8 @@ def test_avalon_sparse_bit_fingerprint(smiles_list, mols_list):
     X_skfp = avalon_fp.transform(smiles_list)
     X_rdkit = csr_array([GetAvalonFP(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), avalon_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), avalon_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -43,7 +44,7 @@ def test_avalon_sparse_count_fingerprint(smiles_list, mols_list):
     X_skfp = avalon_fp.transform(smiles_list)
     X_rdkit = csr_array([GetAvalonCountFP(mol).ToList() for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), avalon_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), avalon_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)

--- a/tests/fingerprints/bcut2d.py
+++ b/tests/fingerprints/bcut2d.py
@@ -27,7 +27,7 @@ def test_bcut2d_fingerprint_gasteiger(gasteiger_allowed_mols):
 
     X_rdkit = np.array([BCUT2D(mol) for mol in gasteiger_allowed_mols])
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(gasteiger_allowed_mols), 8)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -40,7 +40,7 @@ def test_bcut2d_fingerprint_formal(smallest_mols_list):
     bcut2d_fp = BCUT2DFingerprint()
     X_skfp_seq = bcut2d_fp.transform(smallest_mols_list)
 
-    assert np.allclose(X_skfp_parallel, X_skfp_seq)
+    np.testing.assert_allclose(X_skfp_parallel, X_skfp_seq)
     assert X_skfp_parallel.shape == X_skfp_seq.shape
 
 
@@ -51,7 +51,7 @@ def test_bcut2d_ignore_errors(mols_list, gasteiger_allowed_mols):
     X_skfp = bcut2d_fp.transform(mols_list)
     X_skfp_gasteiger = bcut2d_fp.transform(gasteiger_allowed_mols)
 
-    assert np.allclose(X_skfp, X_skfp_gasteiger)
+    np.testing.assert_allclose(X_skfp, X_skfp_gasteiger)
 
 
 def test_bcut2d_zero_errors(mols_list):

--- a/tests/fingerprints/bcut2d.py
+++ b/tests/fingerprints/bcut2d.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import BCUT2D
 
 from skfp.fingerprints import BCUT2DFingerprint
@@ -27,8 +28,8 @@ def test_bcut2d_fingerprint_gasteiger(gasteiger_allowed_mols):
 
     X_rdkit = np.array([BCUT2D(mol) for mol in gasteiger_allowed_mols])
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(gasteiger_allowed_mols), 8)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(gasteiger_allowed_mols), 8))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -40,8 +41,8 @@ def test_bcut2d_fingerprint_formal(smallest_mols_list):
     bcut2d_fp = BCUT2DFingerprint()
     X_skfp_seq = bcut2d_fp.transform(smallest_mols_list)
 
-    np.testing.assert_allclose(X_skfp_parallel, X_skfp_seq)
-    assert X_skfp_parallel.shape == X_skfp_seq.shape
+    assert_allclose(X_skfp_parallel, X_skfp_seq)
+    assert_equal(X_skfp_parallel.shape, X_skfp_seq.shape)
 
 
 def test_bcut2d_ignore_errors(mols_list, gasteiger_allowed_mols):
@@ -51,7 +52,7 @@ def test_bcut2d_ignore_errors(mols_list, gasteiger_allowed_mols):
     X_skfp = bcut2d_fp.transform(mols_list)
     X_skfp_gasteiger = bcut2d_fp.transform(gasteiger_allowed_mols)
 
-    np.testing.assert_allclose(X_skfp, X_skfp_gasteiger)
+    assert_allclose(X_skfp, X_skfp_gasteiger)
 
 
 def test_bcut2d_zero_errors(mols_list):
@@ -60,7 +61,7 @@ def test_bcut2d_zero_errors(mols_list):
     )
     X_skfp = bcut2d_fp.transform(mols_list)
 
-    assert len(X_skfp) == len(mols_list)
+    assert_equal(len(X_skfp), len(mols_list))
 
 
 def test_bcut2d_transform_x_y(mols_list):
@@ -69,7 +70,7 @@ def test_bcut2d_transform_x_y(mols_list):
     bcut2d_fp = BCUT2DFingerprint(n_jobs=-1)
     X_skfp, y_skfp = bcut2d_fp.transform_x_y(mols_list, labels, copy=True)
 
-    assert len(X_skfp) == len(y_skfp)
+    assert_equal(len(X_skfp), len(y_skfp))
     assert np.all(y_skfp == 1)
 
 
@@ -77,9 +78,9 @@ def test_bcut2d_feature_names():
     bcut2d_fp = BCUT2DFingerprint()
     feature_names = bcut2d_fp.get_feature_names_out()
 
-    assert len(feature_names) == bcut2d_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), bcut2d_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "max Burden eigenvalue mass"
-    assert feature_names[1] == "min Burden eigenvalue mass"
-    assert feature_names[-1] == "min Burden eigenvalue MR"
+    assert_equal(feature_names[0], "max Burden eigenvalue mass")
+    assert_equal(feature_names[1], "min Burden eigenvalue mass")
+    assert_equal(feature_names[-1], "min Burden eigenvalue MR")

--- a/tests/fingerprints/e3fp_fp.py
+++ b/tests/fingerprints/e3fp_fp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import scipy.sparse
+from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
 from skfp.fingerprints import E3FPFingerprint
@@ -14,8 +15,8 @@ def test_e3fp_bit_fingerprint(mols_conformers_list):
         [e3fp_fp._calculate_single_mol_fingerprint(mol) for mol in mols_conformers_list]
     )
 
-    assert np.array_equal(X_skfp, X_e3fp)
-    assert X_skfp.shape == (len(mols_conformers_list), e3fp_fp.fp_size)
+    assert_equal(X_skfp, X_e3fp)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), e3fp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -28,8 +29,8 @@ def test_e3fp_count_fingerprint(mols_conformers_list):
         [e3fp_fp._calculate_single_mol_fingerprint(mol) for mol in mols_conformers_list]
     )
 
-    assert np.array_equal(X_skfp, X_e3fp)
-    assert X_skfp.shape == (len(mols_conformers_list), e3fp_fp.fp_size)
+    assert_equal(X_skfp, X_e3fp)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), e3fp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -42,8 +43,8 @@ def test_e3fp_sparse_bit_fingerprint(mols_conformers_list):
         [e3fp_fp._calculate_single_mol_fingerprint(mol) for mol in mols_conformers_list]
     )
 
-    assert np.array_equal(X_skfp.data, X_e3fp.data)
-    assert X_skfp.shape == (len(mols_conformers_list), e3fp_fp.fp_size)
+    assert_equal(X_skfp.data, X_e3fp.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), e3fp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -56,8 +57,8 @@ def test_e3fp_sparse_count_fingerprint(mols_conformers_list):
         [e3fp_fp._calculate_single_mol_fingerprint(mol) for mol in mols_conformers_list]
     )
 
-    assert np.array_equal(X_skfp.data, X_e3fp.data)
-    assert X_skfp.shape == (len(mols_conformers_list), e3fp_fp.fp_size)
+    assert_equal(X_skfp.data, X_e3fp.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), e3fp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 

--- a/tests/fingerprints/ecfp.py
+++ b/tests/fingerprints/ecfp.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem.rdFingerprintGenerator import (
     GetMorganFeatureAtomInvGen,
     GetMorganGenerator,
@@ -15,8 +16,8 @@ def test_ecfp_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetMorganGenerator(radius=2)
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), ecfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), ecfp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -28,8 +29,8 @@ def test_ecfp_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetMorganGenerator(radius=2)
     X_rdkit = np.array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), ecfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), ecfp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -41,8 +42,8 @@ def test_ecfp_sparse_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetMorganGenerator(radius=2)
     X_rdkit = csr_array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), ecfp_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), ecfp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -54,8 +55,8 @@ def test_ecfp_sparse_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetMorganGenerator(radius=2)
     X_rdkit = csr_array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), ecfp_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), ecfp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -69,7 +70,7 @@ def test_pharmacophoric_invariants(smiles_list, mols_list):
     )
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), fcfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), fcfp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))

--- a/tests/fingerprints/electroshape.py
+++ b/tests/fingerprints/electroshape.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.fingerprints import ElectroShapeFingerprint
 from skfp.preprocessing import ConformerGenerator, MolFromSmilesTransformer
@@ -15,7 +16,7 @@ def test_electroshape_bit_fingerprint(mols_conformers_3_plus_atoms):
     electroshape_fp = ElectroShapeFingerprint(n_jobs=-1)
     X_skfp = electroshape_fp.transform(mols_conformers_3_plus_atoms)
 
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 15)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 15))
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert not np.any(np.isnan(X_skfp))
 
@@ -26,10 +27,10 @@ def test_electroshape_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms
     electroshape_fp = ElectroShapeFingerprint(n_jobs=-1)
     X_skfp, y_skfp = electroshape_fp.transform_x_y(mols_conformers_3_plus_atoms, y)
 
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 15)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 15))
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert not np.any(np.isnan(X_skfp))
-    assert len(X_skfp) == len(y_skfp)
+    assert_equal(len(X_skfp), len(y_skfp))
 
 
 def test_electroshape_charge_models(mols_conformers_3_plus_atoms):
@@ -61,18 +62,12 @@ def test_electroshape_ignore_errors():
         "CCCC[SnH](CCCC)CCCC",
     ]
     non_metallics = [
-        # benzene
-        "c1ccccc1",
-        # ibuprofen
-        "CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O",
-        # caffeine
-        "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
-        # nicotine
-        "c1ncccc1[C@@H]2CCCN2C",
-        # Venlafaxine
-        "OC2(C(c1ccc(OC)cc1)CN(C)C)CCCCC2",
-        # Chlordiazepoxide
-        "ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1",
+        "c1ccccc1",  # benzene
+        "CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O",  # ibuprofen
+        "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",  # caffeine
+        "c1ncccc1[C@@H]2CCCN2C",  # nicotine
+        "OC2(C(c1ccc(OC)cc1)CN(C)C)CCCCC2",  # Venlafaxine
+        "ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1",  # Chlordiazepoxide
     ]
     all_smiles = organometallics + non_metallics
     all_mols = MolFromSmilesTransformer().transform(all_smiles)
@@ -81,7 +76,7 @@ def test_electroshape_ignore_errors():
     electroshape_fp = ElectroShapeFingerprint(errors="ignore", n_jobs=-1)
     X_skfp = electroshape_fp.transform(all_mols)
 
-    assert len(X_skfp) == len(all_mols)
+    assert_equal(len(X_skfp), len(all_mols))
 
 
 def test_electroshape_transform_x_y(mols_conformers_3_plus_atoms):
@@ -90,7 +85,7 @@ def test_electroshape_transform_x_y(mols_conformers_3_plus_atoms):
     electroshape_fp = ElectroShapeFingerprint(n_jobs=-1)
     X_skfp, y_skfp = electroshape_fp.transform_x_y(mols_conformers_3_plus_atoms, labels)
 
-    assert len(X_skfp) == len(y_skfp)
+    assert_equal(len(X_skfp), len(y_skfp))
     assert np.all(y_skfp == 1)
 
 
@@ -98,8 +93,10 @@ def test_electroshape_feature_names():
     electroshape_fp = ElectroShapeFingerprint()
     feature_names = electroshape_fp.get_feature_names_out()
 
-    assert len(feature_names) == electroshape_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), electroshape_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "centroid_dists_mean"
-    assert feature_names[-1] == "centroid_lowest_partial_charge_skewness_cubic_root"
+    assert_equal(feature_names[0], "centroid_dists_mean")
+    assert_equal(
+        feature_names[-1], "centroid_lowest_partial_charge_skewness_cubic_root"
+    )

--- a/tests/fingerprints/erg.py
+++ b/tests/fingerprints/erg.py
@@ -62,7 +62,7 @@ def test_erg_fuzzy_sparse_fingerprint(smiles_list):
     mols_list = [MolFromSmiles(smi) for smi in smiles_list]
     X_rdkit = csr_array([GetErGFingerprint(mol) for mol in mols_list])
 
-    assert np.allclose(X_skfp.data, X_rdkit.data)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
     assert X_skfp.shape == (len(smiles_list), 315)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -75,7 +75,7 @@ def test_erg_bit_sparse_fingerprint(smiles_list):
     X_rdkit = csr_array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit.data = X_rdkit.data > 0
 
-    assert np.allclose(X_skfp.data, X_rdkit.data)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
     assert X_skfp.shape == (len(smiles_list), 315)
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
@@ -89,7 +89,7 @@ def test_erg_count_sparse_fingerprint(smiles_list):
     X_rdkit = csr_array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit.data = np.round(X_rdkit.data)
 
-    assert np.allclose(X_skfp.data, X_rdkit.data)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
     assert X_skfp.shape == (len(smiles_list), 315)
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)

--- a/tests/fingerprints/erg.py
+++ b/tests/fingerprints/erg.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import MolFromSmiles
 from rdkit.Chem.rdReducedGraphs import GetErGFingerprint
 from scipy.sparse import csr_array
@@ -21,8 +22,8 @@ def test_erg_fuzzy_fingerprint(smiles_list):
     mols_list = [MolFromSmiles(smi) for smi in smiles_list]
     X_rdkit = np.array([GetErGFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert np.all(X_skfp >= 0)
 
@@ -35,8 +36,8 @@ def test_erg_bit_fingerprint(smiles_list):
     X_rdkit = np.array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit = (X_rdkit > 0).astype(np.uint8)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -49,8 +50,8 @@ def test_erg_count_fingerprint(smiles_list):
     X_rdkit = np.array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit = X_rdkit.round().astype(np.uint32)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -62,8 +63,8 @@ def test_erg_fuzzy_sparse_fingerprint(smiles_list):
     mols_list = [MolFromSmiles(smi) for smi in smiles_list]
     X_rdkit = csr_array([GetErGFingerprint(mol) for mol in mols_list])
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_allclose(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -75,8 +76,8 @@ def test_erg_bit_sparse_fingerprint(smiles_list):
     X_rdkit = csr_array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit.data = X_rdkit.data > 0
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_allclose(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -89,8 +90,8 @@ def test_erg_count_sparse_fingerprint(smiles_list):
     X_rdkit = csr_array([GetErGFingerprint(mol, fuzzIncrement=0) for mol in mols_list])
     X_rdkit.data = np.round(X_rdkit.data)
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 315)
+    assert_allclose(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 315))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 

--- a/tests/fingerprints/estate.py
+++ b/tests/fingerprints/estate.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.EState.Fingerprinter import FingerprintMol
 from scipy.sparse import csr_array
 
@@ -9,12 +10,11 @@ def test_estate_bit_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="bit", n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 0] > 0
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 0] > 0
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 79)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 
@@ -22,12 +22,11 @@ def test_estate_count_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="count", n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 0]
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 0]
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 79)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp >= 0)
 
 
@@ -35,11 +34,10 @@ def test_estate_sum_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="sum", n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 1]
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 1]
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 79)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -47,13 +45,12 @@ def test_estate_sparse_bit_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="bit", sparse=True, n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 0] > 0
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 0] > 0
     X_rdkit = csr_array(X_rdkit)
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 79)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(X_skfp.data == 1)
 
 
@@ -61,13 +58,12 @@ def test_estate_sparse_count_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="count", sparse=True, n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 0]
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 0]
     X_rdkit = csr_array(X_rdkit)
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 79)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp.data > 0)
 
 
@@ -75,12 +71,11 @@ def test_estate_sparse_sum_fingerprint(smiles_list, mols_list):
     estate_fp = EStateFingerprint(variant="sum", sparse=True, n_jobs=-1)
     X_skfp = estate_fp.transform(smiles_list)
 
-    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
-    X_rdkit = X_rdkit[:, 1]
+    X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])[:, 1]
     X_rdkit = csr_array(X_rdkit)
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 79)
+    assert_allclose(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 79))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -88,8 +83,8 @@ def test_estate_feature_names():
     estate_fp = EStateFingerprint()
     feature_names = estate_fp.get_feature_names_out()
 
-    assert len(feature_names) == estate_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), estate_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "[LiD1]-*"
-    assert feature_names[-1] == "[PbD4H0](-*)(-*)(-*)-*"
+    assert_equal(feature_names[0], "[LiD1]-*")
+    assert_equal(feature_names[-1], "[PbD4H0](-*)(-*)(-*)-*")

--- a/tests/fingerprints/estate.py
+++ b/tests/fingerprints/estate.py
@@ -38,7 +38,7 @@ def test_estate_sum_fingerprint(smiles_list, mols_list):
     X_rdkit = np.array([FingerprintMol(mol) for mol in mols_list])
     X_rdkit = X_rdkit[:, 1]
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(smiles_list), 79)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -79,7 +79,7 @@ def test_estate_sparse_sum_fingerprint(smiles_list, mols_list):
     X_rdkit = X_rdkit[:, 1]
     X_rdkit = csr_array(X_rdkit)
 
-    assert np.allclose(X_skfp.data, X_rdkit.data)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
     assert X_skfp.shape == (len(smiles_list), 79)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/functional_groups.py
+++ b/tests/fingerprints/functional_groups.py
@@ -2,6 +2,7 @@ from inspect import getmembers, isfunction
 
 import numpy as np
 import rdkit.Chem.Fragments
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import FunctionalGroupsFingerprint
@@ -22,8 +23,8 @@ def test_functional_groups_bit_fingerprint(smiles_list, mols_list):
     ]
     X_rdkit = np.array(X_rdkit, dtype=np.uint8)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 85)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 85))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -42,8 +43,8 @@ def test_functional_groups_count_fingerprint(smiles_list, mols_list):
     ]
     X_rdkit = np.array(X_rdkit, dtype=np.uint32)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), 85)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), 85))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -63,8 +64,8 @@ def test_functional_groups_sparse_bit_fingerprint(smiles_list, mols_list):
     ]
     X_rdkit = csr_array(X_rdkit, dtype=np.uint8)
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 85)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 85))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -83,8 +84,8 @@ def test_functional_groups_sparse_count_fingerprint(smiles_list, mols_list):
     ]
     X_rdkit = csr_array(X_rdkit, dtype=np.uint32)
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 85)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 85))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -93,14 +94,14 @@ def test_functional_groups_feature_names():
     fg_fp = FunctionalGroupsFingerprint()
     feature_names = fg_fp.get_feature_names_out()
 
-    assert len(feature_names) == fg_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), fg_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
     # compared with https://rdkit.org/docs/source/rdkit.Chem.Fragments.html
-    assert feature_names[0] == "aliphatic carboxylic acids"
-    assert feature_names[1] == "aliphatic hydroxyl groups"
-    assert (
-        feature_names[-2]
-        == "unbranched alkanes of at least 4 members (excludes halogenated alkanes)"
+    assert_equal(feature_names[0], "aliphatic carboxylic acids")
+    assert_equal(feature_names[1], "aliphatic hydroxyl groups")
+    assert_equal(
+        feature_names[-2],
+        "unbranched alkanes of at least 4 members (excludes halogenated alkanes)",
     )
-    assert feature_names[-1] == "urea groups"
+    assert_equal(feature_names[-1], "urea groups")

--- a/tests/fingerprints/getaway.py
+++ b/tests/fingerprints/getaway.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 
 from skfp.fingerprints import GETAWAYFingerprint
 
@@ -7,7 +8,7 @@ def test_getaway_fingerprint(mols_conformers_list):
     getaway_fp = GETAWAYFingerprint(n_jobs=-1)
     X_skfp = getaway_fp.transform(mols_conformers_list)
 
-    assert X_skfp.shape == (len(mols_conformers_list), 273)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 273))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -15,7 +16,7 @@ def test_getaway_sparse_fingerprint(mols_conformers_list):
     getaway_fp = GETAWAYFingerprint(sparse=True, n_jobs=-1)
     X_skfp = getaway_fp.transform(mols_conformers_list)
 
-    assert X_skfp.shape == (len(mols_conformers_list), 273)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 273))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -23,8 +24,8 @@ def test_getaway_feature_names():
     getaway_fp = GETAWAYFingerprint()
     feature_names = getaway_fp.get_feature_names_out()
 
-    assert len(feature_names) == getaway_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), getaway_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
     # for indices understanding, see:
     # https://github.com/rdkit/rdkit/blob/53a01430e057d34cf7a7ca52eb2d8b069178114d/Code/GraphMol/Descriptors/GETAWAY.cpp#L1145

--- a/tests/fingerprints/ghose_crippen.py
+++ b/tests/fingerprints/ghose_crippen.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import GhoseCrippenFingerprint
@@ -9,8 +10,8 @@ def test_ghose_crippen_bit_fingerprint(smiles_list):
     X = gc_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 110))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 110)
     assert np.all(np.isin(X, [0, 1]))
 
 
@@ -19,8 +20,8 @@ def test_ghose_crippen_count_fingerprint(smiles_list):
     X = gc_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 110))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 110)
     assert np.all(X >= 0)
 
 
@@ -29,8 +30,8 @@ def test_ghose_crippen_bit_sparse_fingerprint(smiles_list):
     X = gc_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 110))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 110)
     assert np.all(X.data == 1)
 
 
@@ -39,8 +40,8 @@ def test_ghose_crippen_count_sparse_fingerprint(smiles_list):
     X = gc_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 110))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 110)
     assert np.all(X.data > 0)
 
 
@@ -48,5 +49,5 @@ def test_ghose_crippen_feature_names():
     gc_fp = GhoseCrippenFingerprint()
     feature_names = gc_fp.get_feature_names_out()
 
-    assert len(feature_names) == gc_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), gc_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))

--- a/tests/fingerprints/klekota_roth.py
+++ b/tests/fingerprints/klekota_roth.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit import Chem
 from scipy.sparse import csr_array
 
@@ -13,8 +14,8 @@ def test_klekota_roth_bit_fingerprint(smiles_list):
     X = kr_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 4860))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 4860)
     assert np.all(np.isin(X, [0, 1]))
 
 
@@ -23,8 +24,8 @@ def test_klekota_roth_count_fingerprint(smiles_list):
     X = kr_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 4860))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 4860)
     assert np.all(X >= 0)
 
 
@@ -33,8 +34,8 @@ def test_klekota_roth_bit_sparse_fingerprint(smiles_list):
     X = kr_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 4860))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 4860)
     assert np.all(X.data == 1)
 
 
@@ -43,8 +44,8 @@ def test_klekota_roth_count_sparse_fingerprint(smiles_list):
     X = kr_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 4860))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 4860)
     assert np.all(X.data > 0)
 
 
@@ -52,8 +53,8 @@ def test_klekota_roth_feature_names():
     kr_fp = KlekotaRothFingerprint()
     feature_names = kr_fp.get_feature_names_out()
 
-    assert len(feature_names) == kr_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), kr_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
 
 @pytest.mark.parametrize("count", [False, True])
@@ -80,4 +81,5 @@ def test_klekota_roth_result_correctness(smiles_list, count, n_jobs):
                 expected[j] = n_matches
             elif mol.HasSubstructMatch(patt):
                 expected[j] = 1
-        assert np.array_equal(X[i], expected)
+
+        assert_equal(X[i], expected)

--- a/tests/fingerprints/laggner.py
+++ b/tests/fingerprints/laggner.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import LaggnerFingerprint
@@ -9,8 +10,8 @@ def test_laggner_bit_fingerprint(smiles_list):
     X = laggner_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 307))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 307)
     assert np.all(np.isin(X, [0, 1]))
 
 
@@ -19,8 +20,8 @@ def test_laggner_count_fingerprint(smiles_list):
     X = laggner_fp.transform(smiles_list)
 
     assert isinstance(X, np.ndarray)
+    assert_equal(X.shape, (len(smiles_list), 307))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 307)
     assert np.all(X >= 0)
 
 
@@ -29,8 +30,8 @@ def test_laggner_bit_sparse_fingerprint(smiles_list):
     X = laggner_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 307))
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 307)
     assert np.all(X.data == 1)
 
 
@@ -39,8 +40,8 @@ def test_laggner_count_sparse_fingerprint(smiles_list):
     X = laggner_fp.transform(smiles_list)
 
     assert isinstance(X, csr_array)
+    assert_equal(X.shape, (len(smiles_list), 307))
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 307)
     assert np.all(X.data > 0)
 
 
@@ -52,12 +53,12 @@ def test_laggner_salt_matching():
     laggner_fp = LaggnerFingerprint()
     X = laggner_fp.transform(smiles_list)
 
-    assert X[0, 298] == 0
-    assert X[1, 298] == 0
-    assert X[2, 298] == 0
-    assert X[3, 298] == 0
-    assert X[4, 298] == 1
-    assert X[5, 298] == 1
+    assert_equal(X[0, 298], 0)
+    assert_equal(X[1, 298], 0)
+    assert_equal(X[2, 298], 0)
+    assert_equal(X[3, 298], 0)
+    assert_equal(X[4, 298], 1)
+    assert_equal(X[5, 298], 1)
 
 
 def test_laggner_feature_names():
@@ -65,19 +66,19 @@ def test_laggner_feature_names():
     laggner_fp = LaggnerFingerprint()
     feature_names = laggner_fp.get_feature_names_out()
 
-    assert len(feature_names) == laggner_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), laggner_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "Primary_carbon"
-    assert feature_names[1] == "Secondary_carbon"
-    assert feature_names[2] == "Tertiary_carbon"
-    assert feature_names[3] == "Quaternary_carbon"
+    assert_equal(feature_names[0], "Primary_carbon")
+    assert_equal(feature_names[1], "Secondary_carbon")
+    assert_equal(feature_names[2], "Tertiary_carbon")
+    assert_equal(feature_names[3], "Quaternary_carbon")
 
-    assert feature_names[4] == "Alkene"
-    assert feature_names[5] == "Alkyne"
-    assert feature_names[6] == "Allene"
+    assert_equal(feature_names[4], "Alkene")
+    assert_equal(feature_names[5], "Alkyne")
+    assert_equal(feature_names[6], "Allene")
 
-    assert feature_names[-4] == "Dicarbodiazene"
-    assert feature_names[-3] == "CH-acidic"
-    assert feature_names[-2] == "CH-acidic_strong"
-    assert feature_names[-1] == "Chiral_center_specified"
+    assert_equal(feature_names[-4], "Dicarbodiazene")
+    assert_equal(feature_names[-3], "CH-acidic")
+    assert_equal(feature_names[-2], "CH-acidic_strong")
+    assert_equal(feature_names[-1], "Chiral_center_specified")

--- a/tests/fingerprints/layered.py
+++ b/tests/fingerprints/layered.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem.rdmolops import LayeredFingerprint as RDKitLayeredFingerprint
 from scipy.sparse import csr_array
 from sklearn.utils._param_validation import InvalidParameterError
@@ -12,8 +13,8 @@ def test_layered_fingerprint(smiles_list, mols_list):
     X_skfp = layered_fp.transform(smiles_list)
     X_rdkit = np.array([RDKitLayeredFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), layered_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), layered_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -23,8 +24,8 @@ def test_layered_sparse_fingerprint(smiles_list, mols_list):
     X_skfp = layered_fp.transform(smiles_list)
     X_rdkit = csr_array([RDKitLayeredFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), layered_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), layered_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 

--- a/tests/fingerprints/lingo.py
+++ b/tests/fingerprints/lingo.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array, load_npz
 
 from skfp.fingerprints import LingoFingerprint
@@ -50,8 +51,8 @@ def test_lingo_fingerprint_bit():
 
     expected_array = _load_lingo_data_file(count=False, sparse=False)
 
-    assert np.array_equal(X_skfp, expected_array)
-    assert X_skfp.shape == (2, 1024)
+    assert_equal(X_skfp, expected_array)
+    assert_equal(X_skfp.shape, (2, 1024))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -63,8 +64,8 @@ def test_lingo_fingerprint_count():
 
     expected_array = _load_lingo_data_file(count=True, sparse=False)
 
-    assert np.array_equal(X_skfp, expected_array)
-    assert X_skfp.shape == (2, 1024)
+    assert_equal(X_skfp, expected_array)
+    assert_equal(X_skfp.shape, (2, 1024))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -76,8 +77,8 @@ def test_lingo_fingerprint_bit_sparse():
 
     expected_array = _load_lingo_data_file(count=False, sparse=True)
 
-    assert np.array_equal(X_skfp.data, expected_array.data)
-    assert X_skfp.shape == (2, 1024)
+    assert_equal(X_skfp.data, expected_array.data)
+    assert_equal(X_skfp.shape, (2, 1024))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -89,8 +90,8 @@ def test_lingo_fingerprint_count_sparse():
 
     expected_array = _load_lingo_data_file(count=True, sparse=True)
 
-    assert np.array_equal(X_skfp.data, expected_array.data)
-    assert X_skfp.shape == (2, 1024)
+    assert_equal(X_skfp.data, expected_array.data)
+    assert_equal(X_skfp.shape, (2, 1024))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 

--- a/tests/fingerprints/maccs.py
+++ b/tests/fingerprints/maccs.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem import MolFromSmiles
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
 from scipy.sparse import csr_array
@@ -11,8 +12,8 @@ def test_maccs_bit_fingerprint(smiles_list, mols_list):
     X_skfp = maccs_fp.transform(smiles_list)
     X_rdkit = np.array([GetMACCSKeysFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit[:, 1:])  # ignore first, all-zeros column
-    assert X_skfp.shape == (len(smiles_list), 166)
+    assert_equal(X_skfp, X_rdkit[:, 1:])  # ignore first, all-zeros column
+    assert_equal(X_skfp.shape, (len(smiles_list), 166))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -21,7 +22,7 @@ def test_maccs_count_fingerprint(smiles_list, mols_list):
     maccs_fp = MACCSFingerprint(count=True, n_jobs=-1)
     X_skfp = maccs_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(smiles_list), 157)
+    assert_equal(X_skfp.shape, (len(smiles_list), 157))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -31,8 +32,8 @@ def test_maccs_sparse_bit_fingerprint(smiles_list, mols_list):
     X_skfp = maccs_fp.transform(smiles_list)
     X_rdkit = csr_array([GetMACCSKeysFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), 166)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), 166))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -41,7 +42,7 @@ def test_maccs_sparse_count_fingerprint(smiles_list, mols_list):
     maccs_fp = MACCSFingerprint(count=True, sparse=True, n_jobs=-1)
     X_skfp = maccs_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(smiles_list), 157)
+    assert_equal(X_skfp.shape, (len(smiles_list), 157))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data >= 0)
 
@@ -51,16 +52,16 @@ def test_maccs_feature_names():
     maccs_fp = MACCSFingerprint()
     feature_names = maccs_fp.get_feature_names_out()
 
-    assert len(feature_names) == maccs_fp.n_features_out
+    assert_equal(len(feature_names), maccs_fp.n_features_out)
 
-    assert feature_names[0] == "ISOTOPE"
-    assert feature_names[1] == "atomic num >103"
-    assert feature_names[2] == "Group IVa,Va,VIa Rows 4-6 "
+    assert_equal(feature_names[0], "ISOTOPE")
+    assert_equal(feature_names[1], "atomic num >103")
+    assert_equal(feature_names[2], "Group IVa,Va,VIa Rows 4-6 ")
 
-    assert feature_names[-4] == "6M Ring"
-    assert feature_names[-3] == "O"
-    assert feature_names[-2] == "Ring"
-    assert feature_names[-1] == "Fragments"
+    assert_equal(feature_names[-4], "6M Ring")
+    assert_equal(feature_names[-3], "O")
+    assert_equal(feature_names[-2], "Ring")
+    assert_equal(feature_names[-1], "Fragments")
 
 
 def test_maccs_count_feature_names():
@@ -68,25 +69,25 @@ def test_maccs_count_feature_names():
     maccs_fp = MACCSFingerprint(count=True)
     feature_names = maccs_fp.get_feature_names_out()
 
-    assert len(feature_names) == maccs_fp.n_features_out
+    assert_equal(len(feature_names), maccs_fp.n_features_out)
 
-    assert feature_names[0] == "fragments"
-    assert feature_names[1] == "N"
-    assert feature_names[2] == "O"
-    assert feature_names[3] == "F"
+    assert_equal(feature_names[0], "fragments")
+    assert_equal(feature_names[1], "N")
+    assert_equal(feature_names[2], "O")
+    assert_equal(feature_names[3], "F")
 
-    assert feature_names[-3] == "QCH2A"
-    assert feature_names[-2] == "A!CH2!A"
-    assert feature_names[-1] == "NA(A)A"
+    assert_equal(feature_names[-3], "QCH2A")
+    assert_equal(feature_names[-2], "A!CH2!A")
+    assert_equal(feature_names[-1], "NA(A)A")
 
 
 def test_maccs_patterns():
     maccs_fp = MACCSFingerprint()
     mol = MolFromSmiles("[Na+].[Cl-]")
     counts = maccs_fp._get_maccs_patterns_counts(mol)
-    assert len(counts) == 157
+    assert_equal(len(counts), 157)
 
-    assert counts[0] == 2  # fragments
-    assert counts[1] == 0  # N
-    assert counts[7] == 1  # Cl
-    assert counts[15] == 1  # Na
+    assert_equal(counts[0], 2)  # fragments
+    assert_equal(counts[1], 0)  # N
+    assert_equal(counts[7], 1)  # Cl
+    assert_equal(counts[15], 1)  # Na

--- a/tests/fingerprints/map.py
+++ b/tests/fingerprints/map.py
@@ -1,13 +1,12 @@
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import MAPFingerprint
 
 
 def test_map_bit_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = np.stack(
@@ -17,33 +16,28 @@ def test_map_bit_fingerprint(smallest_smiles_list, smallest_mols_list):
         ],
     )
 
-    assert np.array_equal(X_skfp, X_map)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp, X_map)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 
 def test_map_count_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        verbose=0,
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(verbose=0, n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = np.stack(
         [map_fp._calculate_single_mol_fingerprint(mol) for mol in smallest_mols_list],
     )
 
-    assert np.array_equal(X_skfp, X_map)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp, X_map)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp >= 0)
 
 
 def test_map_raw_hashes_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = np.stack(
@@ -51,16 +45,13 @@ def test_map_raw_hashes_fingerprint(smallest_smiles_list, smallest_mols_list):
         dtype=int,
     )
 
-    assert np.array_equal(X_skfp, X_map)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp, X_map)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert np.issubdtype(X_skfp.dtype, np.integer)
 
 
 def test_map_sparse_bit_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        sparse=True,
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(sparse=True, n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = csr_array(
@@ -70,34 +61,27 @@ def test_map_sparse_bit_fingerprint(smallest_smiles_list, smallest_mols_list):
         ],
     )
 
-    assert np.array_equal(X_skfp.data, X_map.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp.data, X_map.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
 
 def test_map_sparse_count_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        include_duplicated_shingles=True,
-        sparse=True,
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(include_duplicated_shingles=True, sparse=True, n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = csr_array(
         [map_fp._calculate_single_mol_fingerprint(mol) for mol in smallest_mols_list],
     )
 
-    assert np.array_equal(X_skfp.data, X_map.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp.data, X_map.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data > 0)
 
     map_fp = MAPFingerprint(
-        include_duplicated_shingles=True,
-        sparse=True,
-        count=True,
-        n_jobs=-1,
+        include_duplicated_shingles=True, sparse=True, count=True, n_jobs=-1
     )
     X_skfp = map_fp.transform(smallest_smiles_list)
 
@@ -105,17 +89,14 @@ def test_map_sparse_count_fingerprint(smallest_smiles_list, smallest_mols_list):
         [map_fp._calculate_single_mol_fingerprint(mol) for mol in smallest_mols_list],
     )
 
-    assert np.array_equal(X_skfp.data, X_map.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp.data, X_map.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
 
 def test_map_sparse_raw_hashes_fingerprint(smallest_smiles_list, smallest_mols_list):
-    map_fp = MAPFingerprint(
-        sparse=True,
-        n_jobs=-1,
-    )
+    map_fp = MAPFingerprint(sparse=True, n_jobs=-1)
     X_skfp = map_fp.transform(smallest_smiles_list)
 
     X_map = csr_array(
@@ -123,8 +104,8 @@ def test_map_sparse_raw_hashes_fingerprint(smallest_smiles_list, smallest_mols_l
         dtype=int,
     )
 
-    assert np.array_equal(X_skfp.data, X_map.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), map_fp.fp_size)
+    assert_equal(X_skfp.data, X_map.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), map_fp.fp_size))
     assert np.issubdtype(X_skfp.dtype, np.integer)
 
 

--- a/tests/fingerprints/mhfp.py
+++ b/tests/fingerprints/mhfp.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem.rdMHFPFingerprint import MHFPEncoder
 from scipy.sparse import csr_array
 from sklearn.utils._param_validation import InvalidParameterError
@@ -12,17 +13,14 @@ def test_mhfp_bit_fingerprint(smiles_list, mols_list):
     X_skfp = mhfp_fp.transform(smiles_list)
 
     encoder = MHFPEncoder(2048, 0)
-    X_rdkit = MHFPEncoder.EncodeMolsBulk(
-        encoder,
-        mols_list,
-    )
+    X_rdkit = MHFPEncoder.EncodeMolsBulk(encoder, mols_list)
     X_rdkit = np.array(X_rdkit)
     X_rdkit = np.mod(X_rdkit, mhfp_fp.fp_size)
     X_rdkit = np.stack([np.bincount(x, minlength=mhfp_fp.fp_size) for x in X_rdkit])
     X_rdkit = (X_rdkit > 0).astype(int)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -32,16 +30,13 @@ def test_mhfp_count_fingerprint(smiles_list, mols_list):
     X_skfp = mhfp_fp.transform(smiles_list)
 
     encoder = MHFPEncoder(2048, 0)
-    X_rdkit = MHFPEncoder.EncodeMolsBulk(
-        encoder,
-        mols_list,
-    )
+    X_rdkit = MHFPEncoder.EncodeMolsBulk(encoder, mols_list)
     X_rdkit = np.array(X_rdkit)
     X_rdkit = np.mod(X_rdkit, mhfp_fp.fp_size)
     X_rdkit = np.stack([np.bincount(x, minlength=mhfp_fp.fp_size) for x in X_rdkit])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -51,14 +46,11 @@ def test_mhfp_raw_hashes_fingerprint(smiles_list, mols_list):
     X_skfp = mhfp_fp.transform(smiles_list)
 
     encoder = MHFPEncoder(2048, 0)
-    X_rdkit = MHFPEncoder.EncodeMolsBulk(
-        encoder,
-        mols_list,
-    )
+    X_rdkit = MHFPEncoder.EncodeMolsBulk(encoder, mols_list)
     X_rdkit = np.array(X_rdkit)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert np.issubdtype(X_skfp.dtype, np.integer)
     assert np.all(X_skfp >= 0)
 
@@ -68,10 +60,7 @@ def test_mhfp_sparse_bit_fingerprint(smiles_list, mols_list):
     X_skfp = mhfp_fp.transform(smiles_list)
 
     encoder = MHFPEncoder(2048, 0)
-    X_rdkit = MHFPEncoder.EncodeMolsBulk(
-        encoder,
-        mols_list,
-    )
+    X_rdkit = MHFPEncoder.EncodeMolsBulk(encoder, mols_list)
     X_rdkit = np.array(X_rdkit)
     X_rdkit = np.mod(X_rdkit, mhfp_fp.fp_size)
     X_rdkit = csr_array(
@@ -79,8 +68,8 @@ def test_mhfp_sparse_bit_fingerprint(smiles_list, mols_list):
         dtype=int,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -90,10 +79,7 @@ def test_mhfp_sparse_count_fingerprint(smiles_list, mols_list):
     X_skfp = mhfp_fp.transform(smiles_list)
 
     encoder = MHFPEncoder(2048, 0)
-    X_rdkit = MHFPEncoder.EncodeMolsBulk(
-        encoder,
-        mols_list,
-    )
+    X_rdkit = MHFPEncoder.EncodeMolsBulk(encoder, mols_list)
     X_rdkit = np.array(X_rdkit)
     X_rdkit = np.mod(X_rdkit, mhfp_fp.fp_size)
     X_rdkit = csr_array(
@@ -101,8 +87,8 @@ def test_mhfp_sparse_count_fingerprint(smiles_list, mols_list):
         dtype=int,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -115,8 +101,8 @@ def test_mhfp_sparse_raw_hashes_fingerprint(smiles_list):
     X_rdkit = encoder.EncodeSmilesBulk(smiles_list)
     X_rdkit = csr_array(np.array(X_rdkit))
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), mhfp_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), mhfp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data >= 0)
 

--- a/tests/fingerprints/mordred_fp.py
+++ b/tests/fingerprints/mordred_fp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from mordred import Calculator, descriptors
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import MordredFingerprint
@@ -14,7 +14,7 @@ def test_mordred_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
 
-    assert_equal(X_skfp, X_seq, equal_nan=True)
+    assert_allclose(X_skfp, X_seq, equal_nan=True)
     assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1613))
     assert X_skfp.dtype == np.float32
 
@@ -27,7 +27,7 @@ def test_mordred_sparse_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
 
-    assert_equal(X_skfp.data, X_seq.data, equal_nan=True)
+    assert_allclose(X_skfp.data, X_seq.data, equal_nan=True)
     assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1613))
     assert X_skfp.dtype == np.float32
 
@@ -40,7 +40,7 @@ def test_mordred_3D_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
 
-    assert_equal(X_skfp, X_seq, equal_nan=True)
+    assert_allclose(X_skfp, X_seq, equal_nan=True)
     assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1826))
     assert X_skfp.dtype == np.float32
 
@@ -53,7 +53,7 @@ def test_mordred_3D_sparse_fingerprint(smallest_smiles_list, smallest_mols_list)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
 
-    assert_equal(X_skfp.data, X_seq.data, equal_nan=True)
+    assert_allclose(X_skfp.data, X_seq.data, equal_nan=True)
     assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1826))
     assert X_skfp.dtype == np.float32
 

--- a/tests/fingerprints/mordred_fp.py
+++ b/tests/fingerprints/mordred_fp.py
@@ -1,5 +1,6 @@
 import numpy as np
 from mordred import Calculator, descriptors
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import MordredFingerprint
@@ -13,8 +14,8 @@ def test_mordred_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
 
-    assert np.array_equal(X_skfp, X_seq, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_smiles_list), 1613)
+    assert_equal(X_skfp, X_seq, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1613))
     assert X_skfp.dtype == np.float32
 
 
@@ -26,8 +27,8 @@ def test_mordred_sparse_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
 
-    assert np.array_equal(X_skfp.data, X_seq.data, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_smiles_list), 1613)
+    assert_equal(X_skfp.data, X_seq.data, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1613))
     assert X_skfp.dtype == np.float32
 
 
@@ -39,8 +40,8 @@ def test_mordred_3D_fingerprint(smallest_smiles_list, smallest_mols_list):
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = np.array(X_seq, dtype=np.float32)
 
-    assert np.array_equal(X_skfp, X_seq, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_smiles_list), 1826)
+    assert_equal(X_skfp, X_seq, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1826))
     assert X_skfp.dtype == np.float32
 
 
@@ -52,8 +53,8 @@ def test_mordred_3D_sparse_fingerprint(smallest_smiles_list, smallest_mols_list)
     X_seq = [calc(mol) for mol in smallest_mols_list]
     X_seq = csr_array(X_seq, dtype=np.float32)
 
-    assert np.array_equal(X_skfp.data, X_seq.data, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_smiles_list), 1826)
+    assert_equal(X_skfp.data, X_seq.data, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 1826))
     assert X_skfp.dtype == np.float32
 
 
@@ -61,23 +62,23 @@ def test_mordred_feature_names():
     mordred_fp = MordredFingerprint()
     feature_names_skfp = mordred_fp.get_feature_names_out()
 
-    assert len(feature_names_skfp) == mordred_fp.n_features_out
-    assert len(feature_names_skfp) == len(set(feature_names_skfp))
+    assert_equal(len(feature_names_skfp), mordred_fp.n_features_out)
+    assert_equal(len(feature_names_skfp), len(set(feature_names_skfp)))
 
     calc = Calculator(descriptors)
     feature_names_mordred = [str(d) for d in calc.descriptors if d.require_3D is False]
 
-    assert np.array_equal(feature_names_skfp, feature_names_mordred)
+    assert_equal(feature_names_skfp, feature_names_mordred)
 
 
 def test_mordred_3D_feature_names():
     mordred_fp = MordredFingerprint(use_3D=True)
     feature_names_skfp = mordred_fp.get_feature_names_out()
 
-    assert len(feature_names_skfp) == mordred_fp.n_features_out
-    assert len(feature_names_skfp) == len(set(feature_names_skfp))
+    assert_equal(len(feature_names_skfp), mordred_fp.n_features_out)
+    assert_equal(len(feature_names_skfp), len(set(feature_names_skfp)))
 
     calc = Calculator(descriptors, ignore_3D=False)
     feature_names_mordred = [str(d) for d in calc.descriptors]
 
-    assert np.array_equal(feature_names_skfp, feature_names_mordred)
+    assert_equal(feature_names_skfp, feature_names_mordred)

--- a/tests/fingerprints/morse.py
+++ b/tests/fingerprints/morse.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import CalcMORSE
 from scipy.sparse import csr_array
 
@@ -16,8 +17,8 @@ def test_morse_fingerprint(mols_conformers_list):
         ]
     )
 
-    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 224)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 224))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -32,8 +33,8 @@ def test_morse_sparse_fingerprint(mols_conformers_list):
         ]
     )
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 224)
+    assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 224))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -41,10 +42,10 @@ def test_morse_feature_names():
     morse_fp = MORSEFingerprint()
     feature_names = morse_fp.get_feature_names_out()
 
-    assert len(feature_names) == morse_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), morse_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "unweighted 0"
-    assert feature_names[1] == "unweighted 1"
-    assert feature_names[32] == "atomic mass 0"
-    assert feature_names[-1] == "IState 31"
+    assert_equal(feature_names[0], "unweighted 0")
+    assert_equal(feature_names[1], "unweighted 1")
+    assert_equal(feature_names[32], "atomic mass 0")
+    assert_equal(feature_names[-1], "IState 31")

--- a/tests/fingerprints/morse.py
+++ b/tests/fingerprints/morse.py
@@ -16,7 +16,7 @@ def test_morse_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-1)
+    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 224)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -32,7 +32,7 @@ def test_morse_sparse_fingerprint(mols_conformers_list):
         ]
     )
 
-    assert np.allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 224)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/mqns.py
+++ b/tests/fingerprints/mqns.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import MQNsFingerprint
@@ -10,7 +11,7 @@ def test_mqns_bit_fingerprint(smiles_list):
 
     assert isinstance(X, np.ndarray)
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 42)
+    assert_equal(X.shape, (len(smiles_list), 42))
     assert np.all(np.isin(X, [0, 1]))
 
 
@@ -20,7 +21,7 @@ def test_mqns_count_fingerprint(smiles_list):
 
     assert isinstance(X, np.ndarray)
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 42)
+    assert_equal(X.shape, (len(smiles_list), 42))
     assert np.all(X >= 0)
 
 
@@ -30,7 +31,7 @@ def test_mqns_bit_sparse_fingerprint(smiles_list):
 
     assert isinstance(X, csr_array)
     assert X.dtype == np.uint8
-    assert X.shape == (len(smiles_list), 42)
+    assert_equal(X.shape, (len(smiles_list), 42))
     assert np.all(X.data == 1)
 
 
@@ -40,7 +41,7 @@ def test_mqns_count_sparse_fingerprint(smiles_list):
 
     assert isinstance(X, csr_array)
     assert X.dtype == np.uint32
-    assert X.shape == (len(smiles_list), 42)
+    assert_equal(X.shape, (len(smiles_list), 42))
     assert np.all(X.data > 0)
 
 
@@ -48,8 +49,8 @@ def test_mqns_feature_names():
     mqn_fp = MQNsFingerprint()
     feature_names = mqn_fp.get_feature_names_out()
 
-    assert len(feature_names) == mqn_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), mqn_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "C atoms"
-    assert feature_names[-1] == "bonds in >= 2 rings"
+    assert_equal(feature_names[0], "C atoms")
+    assert_equal(feature_names[-1], "bonds in >= 2 rings")

--- a/tests/fingerprints/pattern.py
+++ b/tests/fingerprints/pattern.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem.rdmolops import PatternFingerprint as RDKitPatternFingerprint
 from scipy.sparse import csr_array
 
@@ -10,8 +11,8 @@ def test_pattern_fingerprint(smiles_list, mols_list):
     X_skfp = pattern_fp.transform(smiles_list)
     X_rdkit = np.array([RDKitPatternFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), pattern_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), pattern_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -21,7 +22,7 @@ def test_pattern_sparse_fingerprint(smiles_list, mols_list):
     X_skfp = pattern_fp.transform(smiles_list)
     X_rdkit = csr_array([RDKitPatternFingerprint(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), pattern_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), pattern_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)

--- a/tests/fingerprints/pharmacophore.py
+++ b/tests/fingerprints/pharmacophore.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Get3DDistanceMatrix, Mol
 from rdkit.Chem.ChemicalFeatures import BuildFeatureFactoryFromString
 from rdkit.Chem.Pharm2D import Gobbi_Pharm2D
@@ -14,11 +15,10 @@ def test_pharmacophore_raw_bits_fingerprint(smallest_smiles_list, smallest_mols_
     pharmacophore_fp = PharmacophoreFingerprint(n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list)
-    X_rdkit = np.array(X_rdkit)
+    X_rdkit = np.array(_get_rdkit_pharmacophore_fp(smallest_mols_list))
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smallest_smiles_list), 39972)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 39972))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -27,11 +27,10 @@ def test_pharmacophore_raw_bits_3D_fingerprint(mols_conformers_list):
     pharmacophore_fp = PharmacophoreFingerprint(use_3D=True, n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True)
-    X_rdkit = np.array(X_rdkit)
+    X_rdkit = np.array(_get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True))
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), 39972)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 39972))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -40,13 +39,15 @@ def test_pharmacophore_bit_fingerprint(smallest_smiles_list, smallest_mols_list)
     pharmacophore_fp = PharmacophoreFingerprint(variant="folded", n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=False, sparse=False
+        _get_rdkit_pharmacophore_fp(smallest_mols_list),
+        fp_size=pharmacophore_fp.fp_size,
+        count=False,
+        sparse=False,
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smallest_smiles_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -57,13 +58,15 @@ def test_pharmacophore_bit_3D_fingerprint(mols_conformers_list):
     )
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=False, sparse=False
+        _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=False,
+        sparse=False,
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -72,13 +75,15 @@ def test_pharmacophore_count_fingerprint(smallest_smiles_list, smallest_mols_lis
     pharmacophore_fp = PharmacophoreFingerprint(variant="folded", count=True, n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list, count=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=True, sparse=False
+        _get_rdkit_pharmacophore_fp(smallest_mols_list, count=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=True,
+        sparse=False,
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smallest_smiles_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -89,13 +94,15 @@ def test_pharmacophore_count_3D_fingerprint(mols_conformers_list):
     )
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, count=True, use_3D=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=True, sparse=False
+        _get_rdkit_pharmacophore_fp(mols_conformers_list, count=True, use_3D=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=True,
+        sparse=False,
     )
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_conformers_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -106,11 +113,10 @@ def test_pharmacophore_raw_bits_sparse_fingerprint(
     pharmacophore_fp = PharmacophoreFingerprint(sparse=True, n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list)
-    X_rdkit = csr_array(X_rdkit)
+    X_rdkit = csr_array(_get_rdkit_pharmacophore_fp(smallest_mols_list))
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), 39972)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 39972))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -119,11 +125,10 @@ def test_pharmacophore_raw_bits_3D_sparse_fingerprint(mols_conformers_list):
     pharmacophore_fp = PharmacophoreFingerprint(use_3D=True, sparse=True, n_jobs=-1)
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True)
-    X_rdkit = csr_array(X_rdkit)
+    X_rdkit = csr_array(_get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True))
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_conformers_list), 39972)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 39972))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -134,13 +139,15 @@ def test_pharmacophore_bit_sparse_fingerprint(smallest_smiles_list, smallest_mol
     )
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=False, sparse=True
+        _get_rdkit_pharmacophore_fp(smallest_mols_list),
+        fp_size=pharmacophore_fp.fp_size,
+        count=False,
+        sparse=True,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -151,13 +158,15 @@ def test_pharmacophore_bit_3D_sparse_fingerprint(mols_conformers_list):
     )
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=False, sparse=True
+        _get_rdkit_pharmacophore_fp(mols_conformers_list, use_3D=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=False,
+        sparse=True,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_conformers_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -170,13 +179,15 @@ def test_pharmacophore_count_sparse_fingerprint(
     )
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(smallest_mols_list, count=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=True, sparse=True
+        _get_rdkit_pharmacophore_fp(smallest_mols_list, count=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=True,
+        sparse=True,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smallest_smiles_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -187,13 +198,15 @@ def test_pharmacophore_count_3D_sparse_fingerprint(mols_conformers_list):
     )
     X_skfp = pharmacophore_fp.transform(mols_conformers_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(mols_conformers_list, count=True, use_3D=True)
     X_rdkit = pharmacophore_fp._hash_fingerprint_bits(
-        X_rdkit, fp_size=pharmacophore_fp.fp_size, count=True, sparse=True
+        _get_rdkit_pharmacophore_fp(mols_conformers_list, count=True, use_3D=True),
+        fp_size=pharmacophore_fp.fp_size,
+        count=True,
+        sparse=True,
     )
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_conformers_list), pharmacophore_fp.fp_size)
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), pharmacophore_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -202,29 +215,27 @@ def test_pharmacophore_2_2_points(smallest_smiles_list, smallest_mols_list):
     pharmacophore_fp = PharmacophoreFingerprint(min_points=2, max_points=2)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(
-        smallest_mols_list, min_points=2, max_points=2
+    X_rdkit = np.array(
+        _get_rdkit_pharmacophore_fp(smallest_mols_list, min_points=2, max_points=2)
     )
-    X_rdkit = np.array(X_rdkit)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smallest_smiles_list), 252)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 252))
 
 
 def test_pharmacophore_3_3_points(smallest_smiles_list, smallest_mols_list):
     pharmacophore_fp = PharmacophoreFingerprint(min_points=3, max_points=3)
     X_skfp = pharmacophore_fp.transform(smallest_smiles_list)
 
-    X_rdkit = _get_rdkit_pharmacophore_fp(
-        smallest_mols_list, min_points=3, max_points=3
+    X_rdkit = np.array(
+        _get_rdkit_pharmacophore_fp(smallest_mols_list, min_points=3, max_points=3)
     )
-    X_rdkit = np.array(X_rdkit)
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smallest_smiles_list), 39720)
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smallest_smiles_list), 39720))
 
 
-def test_pharmacophore_wrong_n_points(smallest_smiles_list, smallest_mols_list):
+def test_pharmacophore_wrong_n_points():
     with pytest.raises(ValueError) as exc_info:
         PharmacophoreFingerprint(min_points=3, max_points=2)
     assert "min_points <= max_points" in str(exc_info)
@@ -255,8 +266,7 @@ def _get_rdkit_pharmacophore_fp(
         Get3DDistanceMatrix(mol, confId=mol.GetIntProp("conf_id")) if use_3D else None
         for mol in mols
     ]
-    X = [
+    return [
         Gen2DFingerprint(mol, factory, dMat=dists_3d)
         for mol, dists_3d in zip(mols, dists_3d_list, strict=False)
     ]
-    return X

--- a/tests/fingerprints/physiochemical_properties.py
+++ b/tests/fingerprints/physiochemical_properties.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import PhysiochemicalPropertiesFingerprint
@@ -9,7 +10,7 @@ def test_physiochemical_properties_bp_bit_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, np.ndarray)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -19,7 +20,7 @@ def test_physiochemical_properties_bp_count_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, np.ndarray)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -29,7 +30,7 @@ def test_physiochemical_properties_bt_bit_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, np.ndarray)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -39,7 +40,7 @@ def test_physiochemical_properties_bt_count_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, np.ndarray)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -49,7 +50,7 @@ def test_physiochemical_properties_bp_sparse_bit_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, csr_array)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -61,7 +62,7 @@ def test_physiochemical_properties_bp_sparse_count_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, csr_array)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -71,7 +72,7 @@ def test_physiochemical_properties_bt_sparse_bit_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, csr_array)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint8
     assert np.all(X_skfp.data == 1)
 
@@ -83,6 +84,6 @@ def test_physiochemical_properties_bt_sparse_count_fingerprint(smiles_list):
     X_skfp = pp_fp.transform(smiles_list)
 
     assert isinstance(X_skfp, csr_array)
-    assert X_skfp.shape == (len(smiles_list), pp_fp.fp_size)
+    assert_equal(X_skfp.shape, (len(smiles_list), pp_fp.fp_size))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)

--- a/tests/fingerprints/pubchem.py
+++ b/tests/fingerprints/pubchem.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem import MolFromSmiles
 
 from skfp.fingerprints import PubChemFingerprint
@@ -9,7 +10,7 @@ def test_pubchem_bit_fingerprint(smiles_list, mols_list):
     pubchem_fp = PubChemFingerprint(n_jobs=-1)
     X_skfp = pubchem_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(mols_list), 881)
+    assert_equal(X_skfp.shape, (len(mols_list), 881))
     assert X_skfp.dtype == np.uint8
     assert np.all(np.isin(X_skfp, [0, 1]))
 
@@ -18,7 +19,7 @@ def test_pubchem_count_fingerprint(smiles_list, mols_list):
     pubchem_fp = PubChemFingerprint(count=True, n_jobs=-1)
     X_skfp = pubchem_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(mols_list), 757)
+    assert_equal(X_skfp.shape, (len(mols_list), 757))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp >= 0)
 
@@ -27,16 +28,16 @@ def test_pubchem_sparse_bit_fingerprint(smiles_list, mols_list):
     pubchem_fp = PubChemFingerprint(sparse=True, n_jobs=-1)
     X_skfp = pubchem_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(mols_list), 881)
+    assert_equal(X_skfp.shape, (len(mols_list), 881))
     assert X_skfp.dtype == np.uint8
-    np.testing.assert_allclose(X_skfp.data, 1)
+    assert_allclose(X_skfp.data, 1)
 
 
 def test_pubchem_sparse_count_fingerprint(smiles_list, mols_list):
     pubchem_fp = PubChemFingerprint(count=True, sparse=True, n_jobs=-1)
     X_skfp = pubchem_fp.transform(smiles_list)
 
-    assert X_skfp.shape == (len(mols_list), 757)
+    assert_equal(X_skfp.shape, (len(mols_list), 757))
     assert X_skfp.dtype == np.uint32
     assert np.all(X_skfp.data > 0)
 
@@ -45,21 +46,21 @@ def test_pubchem_patterns():
     pubchem_fp = PubChemFingerprint(count=True)
     mol = MolFromSmiles("[Na+].[Cl-]")
     counts = pubchem_fp._get_pubchem_fingerprint(mol)
-    assert len(counts) == 757
+    assert_equal(len(counts), 757)
 
-    assert counts[0] == 0  # H
-    assert counts[7] == 1  # Na
-    assert counts[11] == 1  # Cl
+    assert_equal(counts[0], 0)  # H
+    assert_equal(counts[7], 1)  # Na
+    assert_equal(counts[11], 1)  # Cl
 
     # no rings, no features other than Na and Cl
-    assert counts.sum() == 2
+    assert_equal(counts.sum(), 2)
 
 
 @pytest.mark.parametrize("fp", [PubChemFingerprint(), PubChemFingerprint(count=True)])
 def test_pubchem_feature_names(fp):
     feature_names = fp.get_feature_names_out()
-    assert len(feature_names) == fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
     assert feature_names[0].startswith("H")
-    assert feature_names[-1] == "Br[#6]1[#6](Br)[#6][#6][#6]1"
+    assert_equal(feature_names[-1], "Br[#6]1[#6](Br)[#6][#6][#6]1")

--- a/tests/fingerprints/pubchem.py
+++ b/tests/fingerprints/pubchem.py
@@ -29,7 +29,7 @@ def test_pubchem_sparse_bit_fingerprint(smiles_list, mols_list):
 
     assert X_skfp.shape == (len(mols_list), 881)
     assert X_skfp.dtype == np.uint8
-    assert np.allclose(X_skfp.data, 1)
+    np.testing.assert_allclose(X_skfp.data, 1)
 
 
 def test_pubchem_sparse_count_fingerprint(smiles_list, mols_list):

--- a/tests/fingerprints/rdf.py
+++ b/tests/fingerprints/rdf.py
@@ -13,7 +13,7 @@ def test_rdf_fingerprint(mols_conformers_list):
         [CalcRDF(mol, confId=mol.GetIntProp("conf_id")) for mol in mols_conformers_list]
     )
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-1)
+    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 210)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -26,7 +26,7 @@ def test_rdf_sparse_fingerprint(mols_conformers_list):
         [CalcRDF(mol, confId=mol.GetIntProp("conf_id")) for mol in mols_conformers_list]
     )
 
-    assert np.allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 210)
 
 

--- a/tests/fingerprints/rdf.py
+++ b/tests/fingerprints/rdf.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import CalcRDF
 from scipy.sparse import csr_array
 
@@ -13,8 +14,8 @@ def test_rdf_fingerprint(mols_conformers_list):
         [CalcRDF(mol, confId=mol.GetIntProp("conf_id")) for mol in mols_conformers_list]
     )
 
-    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 210)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 210))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -26,18 +27,18 @@ def test_rdf_sparse_fingerprint(mols_conformers_list):
         [CalcRDF(mol, confId=mol.GetIntProp("conf_id")) for mol in mols_conformers_list]
     )
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 210)
+    assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 210))
 
 
 def test_rdf_feature_names():
     rdf_fp = RDFFingerprint()
     feature_names = rdf_fp.get_feature_names_out()
 
-    assert len(feature_names) == rdf_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), rdf_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "unweighted 1"
-    assert feature_names[1] == "unweighted 2"
-    assert feature_names[30] == "atomic mass 1"
-    assert feature_names[-1] == "IState 30"
+    assert_equal(feature_names[0], "unweighted 1")
+    assert_equal(feature_names[1], "unweighted 2")
+    assert_equal(feature_names[30], "atomic mass 1")
+    assert_equal(feature_names[-1], "IState 30")

--- a/tests/fingerprints/rdkit_2d_desc.py
+++ b/tests/fingerprints/rdkit_2d_desc.py
@@ -1,5 +1,6 @@
 import numpy as np
 from descriptastorus.descriptors import RDKit2D, RDKit2DNormalized
+from numpy.testing import assert_allclose, assert_equal
 from scipy.sparse import csr_array
 
 from skfp.fingerprints import RDKit2DDescriptorsFingerprint
@@ -18,8 +19,8 @@ def test_rdkit_2d_desc_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.array(X_descriptastorus, dtype=np.float32)
 
-    np.testing.assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_mols_list), 200)
+    assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_mols_list), 200))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -35,10 +36,8 @@ def test_rdkit_2d_desc_sparse_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
 
-    np.testing.assert_allclose(
-        X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True
-    )  # type: ignore
-    assert X_skfp.shape == (len(smallest_mols_list), 200)
+    assert_allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_mols_list), 200))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -54,8 +53,8 @@ def test_rdkit_2d_desc_normalized_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.vstack(X_descriptastorus)
 
-    np.testing.assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
-    assert X_skfp.shape == (len(smallest_mols_list), 200)
+    assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_mols_list), 200))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -73,10 +72,8 @@ def test_rdkit_2d_desc_normalized_sparse_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
 
-    np.testing.assert_allclose(
-        X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True
-    )  # type: ignore
-    assert X_skfp.shape == (len(smallest_mols_list), 200)
+    assert_allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)
+    assert_equal(X_skfp.shape, (len(smallest_mols_list), 200))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -84,8 +81,8 @@ def test_rdkit_2d_desc_feature_names():
     rdkit_2d_desc_fp = RDKit2DDescriptorsFingerprint()
     feature_names_skfp = rdkit_2d_desc_fp.get_feature_names_out()
 
-    assert len(feature_names_skfp) == rdkit_2d_desc_fp.n_features_out
-    assert len(feature_names_skfp) == len(set(feature_names_skfp))
+    assert_equal(len(feature_names_skfp), rdkit_2d_desc_fp.n_features_out)
+    assert_equal(len(feature_names_skfp), len(set(feature_names_skfp)))
 
     gen = RDKit2DNormalized()
     feature_names_rdkit = np.asarray([name for name, obj in gen.columns])

--- a/tests/fingerprints/rdkit_2d_desc.py
+++ b/tests/fingerprints/rdkit_2d_desc.py
@@ -18,7 +18,7 @@ def test_rdkit_2d_desc_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.array(X_descriptastorus, dtype=np.float32)
 
-    assert np.allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
+    np.testing.assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -35,7 +35,9 @@ def test_rdkit_2d_desc_sparse_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
 
-    assert np.allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)  # type: ignore
+    np.testing.assert_allclose(
+        X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True
+    )  # type: ignore
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -52,7 +54,7 @@ def test_rdkit_2d_desc_normalized_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = np.vstack(X_descriptastorus)
 
-    assert np.allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
+    np.testing.assert_allclose(X_skfp, X_descriptastorus, atol=1e-3, equal_nan=True)
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -71,7 +73,9 @@ def test_rdkit_2d_desc_normalized_sparse_fingerprint(smallest_mols_list):
     X_descriptastorus = [np.clip(x, -2147483647, 2147483647) for x in X_descriptastorus]
     X_descriptastorus = csr_array(X_descriptastorus)
 
-    assert np.allclose(X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True)  # type: ignore
+    np.testing.assert_allclose(
+        X_skfp.data, X_descriptastorus.data, atol=1e-3, equal_nan=True
+    )  # type: ignore
     assert X_skfp.shape == (len(smallest_mols_list), 200)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/rdkit_fp.py
+++ b/tests/fingerprints/rdkit_fp.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem.rdFingerprintGenerator import (
     GetMorganFeatureAtomInvGen,
     GetRDKitFPGenerator,
@@ -17,9 +18,9 @@ def test_rdkit_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetRDKitFPGenerator(countSimulation=False)
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), rdkit_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), rdkit_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 
@@ -30,9 +31,9 @@ def test_rdkit_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetRDKitFPGenerator(countSimulation=True)
     X_rdkit = np.array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), rdkit_fp.fp_size)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), rdkit_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp >= 0)
 
 
@@ -43,9 +44,9 @@ def test_rdkit_sparse_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetRDKitFPGenerator(countSimulation=False)
     X_rdkit = csr_array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), rdkit_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), rdkit_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(X_skfp.data == 1)
 
 
@@ -56,9 +57,9 @@ def test_rdkit_sparse_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetRDKitFPGenerator(countSimulation=True)
     X_rdkit = csr_array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), rdkit_fp.fp_size)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), rdkit_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp.data > 0)
 
 
@@ -69,9 +70,9 @@ def test_pharmacophoric_invariants(smiles_list, mols_list):
     fp_gen = GetRDKitFPGenerator(atomInvariantsGenerator=GetMorganFeatureAtomInvGen())
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), pharma_rdkit_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), pharma_rdkit_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 

--- a/tests/fingerprints/secfp.py
+++ b/tests/fingerprints/secfp.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem.rdMHFPFingerprint import MHFPEncoder
 from scipy.sparse import csr_array
 from sklearn.utils._param_validation import InvalidParameterError
@@ -14,9 +15,9 @@ def test_secfp_fingerprint(smiles_list, mols_list):
     encoder = MHFPEncoder(2048, 0)
     X_rdkit = np.array([encoder.EncodeSECFPMol(x) for x in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), secfp_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), secfp_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 
@@ -27,9 +28,9 @@ def test_secfp_sparse_fingerprint(smiles_list, mols_list):
     encoder = MHFPEncoder(2048, 0)
     X_rdkit = csr_array([encoder.EncodeSECFPMol(x) for x in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), secfp_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), secfp_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(X_skfp.data == 1)
 
 

--- a/tests/fingerprints/topological_torsion.py
+++ b/tests/fingerprints/topological_torsion.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem.rdFingerprintGenerator import (
     GetMorganFeatureAtomInvGen,
     GetTopologicalTorsionGenerator,
@@ -15,9 +16,9 @@ def test_topological_torsion_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetTopologicalTorsionGenerator()
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), tt_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), tt_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))
 
 
@@ -28,9 +29,9 @@ def test_topological_torsion_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetTopologicalTorsionGenerator()
     X_rdkit = np.array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), tt_fp.fp_size)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), tt_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp >= 0)
 
 
@@ -41,9 +42,9 @@ def test_topological_torsion_sparse_bit_fingerprint(smiles_list, mols_list):
     fp_gen = GetTopologicalTorsionGenerator()
     X_rdkit = csr_array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), tt_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), tt_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(X_skfp.data == 1)
 
 
@@ -54,9 +55,9 @@ def test_topological_torsion_sparse_count_fingerprint(smiles_list, mols_list):
     fp_gen = GetTopologicalTorsionGenerator()
     X_rdkit = csr_array([fp_gen.GetCountFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(smiles_list), tt_fp.fp_size)
-    assert X_skfp.dtype == np.uint32
+    assert_equal(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(smiles_list), tt_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint32)
     assert np.all(X_skfp.data > 0)
 
 
@@ -71,7 +72,7 @@ def test_pharmacophoric_invariants(smiles_list, mols_list):
     )
     X_rdkit = np.array([fp_gen.GetFingerprintAsNumPy(mol) for mol in mols_list])
 
-    assert np.array_equal(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(smiles_list), pharma_tt_fp.fp_size)
-    assert X_skfp.dtype == np.uint8
+    assert_equal(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(smiles_list), pharma_tt_fp.fp_size))
+    assert_equal(X_skfp.dtype, np.uint8)
     assert np.all(np.isin(X_skfp, [0, 1]))

--- a/tests/fingerprints/usr.py
+++ b/tests/fingerprints/usr.py
@@ -22,7 +22,7 @@ def test_usr_bit_fingerprint(mols_conformers_3_plus_atoms):
         ]
     )
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-3)
+    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-3)
     assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 12)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -43,7 +43,7 @@ def test_usr_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms):
     X_rdkit = np.array(X_rdkit)
     y_rdkit = np.array(y_rdkit)
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-3)
+    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-3)
     assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 12)
     assert np.issubdtype(X_skfp.dtype, np.floating)
     assert np.array_equal(y_skfp, y_rdkit)
@@ -54,7 +54,7 @@ def test_usr_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms):
     X_skfp = usr_fp.transform(mols_conformers_list)
     X_skfp_3_plus_atoms = usr_fp.transform(mols_conformers_3_plus_atoms)
 
-    assert np.allclose(X_skfp, X_skfp_3_plus_atoms)
+    np.testing.assert_allclose(X_skfp, X_skfp_3_plus_atoms)
 
 
 def test_usr_copy(mols_conformers_3_plus_atoms):

--- a/tests/fingerprints/usr.py
+++ b/tests/fingerprints/usr.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import GetUSR
 
 from skfp.fingerprints import USRFingerprint
@@ -7,7 +8,6 @@ from skfp.fingerprints import USRFingerprint
 
 @pytest.fixture
 def mols_conformers_3_plus_atoms(mols_conformers_list):
-    # USR descriptor requires at least 3 atoms to work
     return [mol for mol in mols_conformers_list if mol.GetNumAtoms() >= 3]
 
 
@@ -22,8 +22,8 @@ def test_usr_bit_fingerprint(mols_conformers_3_plus_atoms):
         ]
     )
 
-    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-3)
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 12)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-3)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 12))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -33,20 +33,16 @@ def test_usr_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms):
     usr_fp = USRFingerprint()
     X_skfp, y_skfp = usr_fp.transform_x_y(mols_conformers_3_plus_atoms, labels)
 
-    X_rdkit = []
-    y_rdkit = []
-    for mol, y in zip(mols_conformers_3_plus_atoms, labels, strict=False):
-        mol_fp = GetUSR(mol, confId=mol.GetIntProp("conf_id"))
-        X_rdkit.append(mol_fp)
-        y_rdkit.append(y)
+    X_rdkit = [
+        GetUSR(mol, confId=mol.GetIntProp("conf_id"))
+        for mol in mols_conformers_3_plus_atoms
+    ]
+    y_rdkit = labels
 
-    X_rdkit = np.array(X_rdkit)
-    y_rdkit = np.array(y_rdkit)
-
-    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-3)
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 12)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-3)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 12))
     assert np.issubdtype(X_skfp.dtype, np.floating)
-    assert np.array_equal(y_skfp, y_rdkit)
+    assert_equal(y_skfp, y_rdkit)
 
 
 def test_usr_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms):
@@ -54,19 +50,17 @@ def test_usr_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms):
     X_skfp = usr_fp.transform(mols_conformers_list)
     X_skfp_3_plus_atoms = usr_fp.transform(mols_conformers_3_plus_atoms)
 
-    np.testing.assert_allclose(X_skfp, X_skfp_3_plus_atoms)
+    assert_allclose(X_skfp, X_skfp_3_plus_atoms)
 
 
 def test_usr_copy(mols_conformers_3_plus_atoms):
-    # smoke test, should not throw an error
     labels = np.ones(len(mols_conformers_3_plus_atoms))
-
     usr_fp = USRFingerprint(errors="ignore", n_jobs=-1)
     fps, labels_out = usr_fp.transform_x_y(
         mols_conformers_3_plus_atoms, labels, copy=True
     )
 
-    assert np.array_equal(labels, labels_out)
+    assert_equal(labels, labels_out)
     assert labels is not labels_out
 
 
@@ -74,8 +68,10 @@ def test_usr_feature_names():
     usr_fp = USRFingerprint()
     feature_names = usr_fp.get_feature_names_out()
 
-    assert len(feature_names) == usr_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), usr_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "centroid_dists_mean"
-    assert feature_names[-1] == "farthest_atom_from_farthest_to_centroid_cubic_root"
+    assert_equal(feature_names[0], "centroid_dists_mean")
+    assert_equal(
+        feature_names[-1], "farthest_atom_from_farthest_to_centroid_cubic_root"
+    )

--- a/tests/fingerprints/usrcat.py
+++ b/tests/fingerprints/usrcat.py
@@ -8,7 +8,6 @@ from skfp.fingerprints import USRCATFingerprint
 
 @pytest.fixture
 def mols_conformers_3_plus_atoms(mols_conformers_list):
-    # USRCAT descriptor requires at least 3 atoms to work
     return [mol for mol in mols_conformers_list if mol.GetNumAtoms() >= 3]
 
 
@@ -30,19 +29,14 @@ def test_usrcat_bit_fingerprint(mols_conformers_3_plus_atoms):
 
 def test_usrcat_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms):
     labels = np.arange(len(mols_conformers_3_plus_atoms))
-
     usrcat_fp = USRCATFingerprint()
     X_skfp, y_skfp = usrcat_fp.transform_x_y(mols_conformers_3_plus_atoms, labels)
 
-    X_rdkit = []
-    y_rdkit = []
-    for mol, y in zip(mols_conformers_3_plus_atoms, labels, strict=False):
-        mol_fp = GetUSRCAT(mol, confId=mol.GetIntProp("conf_id"))
-        X_rdkit.append(mol_fp)
-        y_rdkit.append(y)
-
-    X_rdkit = np.array(X_rdkit)
-    y_rdkit = np.array(y_rdkit)
+    X_rdkit = [
+        GetUSRCAT(mol, confId=mol.GetIntProp("conf_id"))
+        for mol in mols_conformers_3_plus_atoms
+    ]
+    y_rdkit = labels
 
     assert_allclose(X_skfp, X_rdkit, atol=1e-3)
     assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 60))
@@ -59,15 +53,13 @@ def test_usrcat_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms
 
 
 def test_usrcat_copy(mols_conformers_3_plus_atoms):
-    # smoke test, should not throw an error
     labels = np.ones(len(mols_conformers_3_plus_atoms))
-
     usrcat_fp = USRCATFingerprint(errors="ignore", n_jobs=-1)
     fps, labels_out = usrcat_fp.transform_x_y(
         mols_conformers_3_plus_atoms, labels, copy=True
     )
 
-    np.testing.assert_array_equal(labels, labels_out)
+    assert_equal(labels, labels_out)
     assert labels is not labels_out
 
 

--- a/tests/fingerprints/usrcat.py
+++ b/tests/fingerprints/usrcat.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import GetUSRCAT
 
 from skfp.fingerprints import USRCATFingerprint
@@ -22,8 +23,8 @@ def test_usrcat_bit_fingerprint(mols_conformers_3_plus_atoms):
         ]
     )
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-3)
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 60)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-3)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 60))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -43,10 +44,10 @@ def test_usrcat_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms):
     X_rdkit = np.array(X_rdkit)
     y_rdkit = np.array(y_rdkit)
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-3)
-    assert X_skfp.shape == (len(mols_conformers_3_plus_atoms), 60)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-3)
+    assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 60))
     assert np.issubdtype(X_skfp.dtype, np.floating)
-    assert np.array_equal(y_skfp, y_rdkit)
+    assert_equal(y_skfp, y_rdkit)
 
 
 def test_usrcat_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms):
@@ -54,7 +55,7 @@ def test_usrcat_ignore_errors(mols_conformers_list, mols_conformers_3_plus_atoms
     X_skfp = usrcat_fp.transform(mols_conformers_list)
     X_skfp_3_plus_atoms = usrcat_fp.transform(mols_conformers_3_plus_atoms)
 
-    assert np.allclose(X_skfp, X_skfp_3_plus_atoms)
+    assert_allclose(X_skfp, X_skfp_3_plus_atoms)
 
 
 def test_usrcat_copy(mols_conformers_3_plus_atoms):
@@ -66,7 +67,7 @@ def test_usrcat_copy(mols_conformers_3_plus_atoms):
         mols_conformers_3_plus_atoms, labels, copy=True
     )
 
-    assert np.array_equal(labels, labels_out)
+    np.testing.assert_array_equal(labels, labels_out)
     assert labels is not labels_out
 
 
@@ -74,29 +75,30 @@ def test_usrcat_feature_names():
     usrcat_fp = USRCATFingerprint()
     feature_names = usrcat_fp.get_feature_names_out()
 
-    assert len(feature_names) == usrcat_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), usrcat_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "all_centroid_dists_mean"
-    assert feature_names[12] == "hydrophobic_centroid_dists_mean"
-    assert feature_names[24] == "aromatic_centroid_dists_mean"
-    assert feature_names[36] == "hydrogen_bond_donor_centroid_dists_mean"
-    assert feature_names[48] == "hydrogen_bond_acceptor_centroid_dists_mean"
+    assert_equal(feature_names[0], "all_centroid_dists_mean")
+    assert_equal(feature_names[12], "hydrophobic_centroid_dists_mean")
+    assert_equal(feature_names[24], "aromatic_centroid_dists_mean")
+    assert_equal(feature_names[36], "hydrogen_bond_donor_centroid_dists_mean")
+    assert_equal(feature_names[48], "hydrogen_bond_acceptor_centroid_dists_mean")
 
-    assert feature_names[11] == "all_farthest_atom_from_farthest_to_centroid_cubic_root"
-    assert (
-        feature_names[23]
-        == "hydrophobic_farthest_atom_from_farthest_to_centroid_cubic_root"
+    assert_equal(
+        feature_names[11], "all_farthest_atom_from_farthest_to_centroid_cubic_root"
     )
-    assert (
-        feature_names[35]
-        == "aromatic_farthest_atom_from_farthest_to_centroid_cubic_root"
+    assert_equal(
+        feature_names[23],
+        "hydrophobic_farthest_atom_from_farthest_to_centroid_cubic_root",
     )
-    assert (
-        feature_names[47]
-        == "hydrogen_bond_donor_farthest_atom_from_farthest_to_centroid_cubic_root"
+    assert_equal(
+        feature_names[35], "aromatic_farthest_atom_from_farthest_to_centroid_cubic_root"
     )
-    assert (
-        feature_names[59]
-        == "hydrogen_bond_acceptor_farthest_atom_from_farthest_to_centroid_cubic_root"
+    assert_equal(
+        feature_names[47],
+        "hydrogen_bond_donor_farthest_atom_from_farthest_to_centroid_cubic_root",
+    )
+    assert_equal(
+        feature_names[59],
+        "hydrogen_bond_acceptor_farthest_atom_from_farthest_to_centroid_cubic_root",
     )

--- a/tests/fingerprints/vsa.py
+++ b/tests/fingerprints/vsa.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.EState.EState_VSA import EState_VSA_
 from rdkit.Chem.rdMolDescriptors import PEOE_VSA_, SMR_VSA_, SlogP_VSA_
 from scipy.sparse import csr_array
@@ -17,8 +18,8 @@ def test_vsa_fingerprint(mols_list):
 
     X_rdkit = np.column_stack((X_slogp, X_smr, X_peoe))
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_list), 36)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_list), 36))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -33,8 +34,8 @@ def test_vsa_fingerprint_with_estate(mols_list):
 
     X_rdkit = np.column_stack((X_slogp, X_smr, X_peoe, X_estate))
 
-    np.testing.assert_allclose(X_skfp, X_rdkit)
-    assert X_skfp.shape == (len(mols_list), 47)
+    assert_allclose(X_skfp, X_rdkit)
+    assert_equal(X_skfp.shape, (len(mols_list), 47))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -50,7 +51,7 @@ def test_vsa_fingerprint_variants(mols_list):
         vsa_fp = VSAFingerprint(variant=variant, n_jobs=-1)
         X_skfp = vsa_fp.transform(mols_list)
 
-        assert X_skfp.shape == (len(mols_list), expected_num_cols)
+        assert_equal(X_skfp.shape, (len(mols_list), expected_num_cols))
         assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -64,8 +65,8 @@ def test_vsa_sparse_fingerprint(mols_list):
 
     X_rdkit = csr_array(np.column_stack((X_slogp, X_smr, X_peoe)))
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
-    assert X_skfp.shape == (len(mols_list), 36)
+    assert_allclose(X_skfp.data, X_rdkit.data)
+    assert_equal(X_skfp.shape, (len(mols_list), 36))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -73,68 +74,60 @@ def test_vsa_slogp_feature_names():
     vsa_fp = VSAFingerprint(variant="SlogP", n_jobs=-1)
     feature_names = vsa_fp.get_feature_names_out()
 
-    assert len(feature_names) == vsa_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), vsa_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    # bins: https://github.com/rdkit/rdkit/blob/68672864c615f2ba75ddcbb40436fa107a611f34/rdkit/Chem/MolSurf.py#L154
-    # logpBins = [-0.4, -0.2, 0, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6]  # noqa: ERA001
-    assert feature_names[0] == "SlogP < -0.4"
-    assert feature_names[1] == "-0.4 <= SlogP < -0.2"
-    assert feature_names[-2] == "0.5 <= SlogP < 0.6"
-    assert feature_names[-1] == "SlogP >= 0.6"
+    assert_equal(feature_names[0], "SlogP < -0.4")
+    assert_equal(feature_names[1], "-0.4 <= SlogP < -0.2")
+    assert_equal(feature_names[-2], "0.5 <= SlogP < 0.6")
+    assert_equal(feature_names[-1], "SlogP >= 0.6")
 
 
 def test_vsa_smr_feature_names():
     vsa_fp = VSAFingerprint(variant="SMR", n_jobs=-1)
     feature_names = vsa_fp.get_feature_names_out()
 
-    assert len(feature_names) == vsa_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), vsa_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    # bins: https://github.com/rdkit/rdkit/blob/68672864c615f2ba75ddcbb40436fa107a611f34/rdkit/Chem/MolSurf.py#L115
-    # mrBins = [1.29, 1.82, 2.24, 2.45, 2.75, 3.05, 3.63, 3.8, 4.0]  # noqa: ERA001
-    assert feature_names[0] == "SMR < 1.29"
-    assert feature_names[1] == "1.29 <= SMR < 1.82"
-    assert feature_names[-2] == "3.8 <= SMR < 4.0"
-    assert feature_names[-1] == "SMR >= 4.0"
+    assert_equal(feature_names[0], "SMR < 1.29")
+    assert_equal(feature_names[1], "1.29 <= SMR < 1.82")
+    assert_equal(feature_names[-2], "3.8 <= SMR < 4.0")
+    assert_equal(feature_names[-1], "SMR >= 4.0")
 
 
 def test_vsa_peoe_feature_names():
     vsa_fp = VSAFingerprint(variant="PEOE", n_jobs=-1)
     feature_names = vsa_fp.get_feature_names_out()
 
-    assert len(feature_names) == vsa_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), vsa_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    # bins: https://github.com/rdkit/rdkit/blob/68672864c615f2ba75ddcbb40436fa107a611f34/rdkit/Chem/MolSurf.py#L189
-    # chgBins = [-.3, -.25, -.20, -.15, -.10, -.05, 0, .05, .10, .15, .20, .25, .30]  # noqa: ERA001
-    assert feature_names[0] == "PEOE < -0.3"
-    assert feature_names[1] == "-0.3 <= PEOE < -0.25"
-    assert feature_names[-2] == "0.25 <= PEOE < 0.3"
-    assert feature_names[-1] == "PEOE >= 0.3"
+    assert_equal(feature_names[0], "PEOE < -0.3")
+    assert_equal(feature_names[1], "-0.3 <= PEOE < -0.25")
+    assert_equal(feature_names[-2], "0.25 <= PEOE < 0.3")
+    assert_equal(feature_names[-1], "PEOE >= 0.3")
 
 
 def test_vsa_estate_feature_names():
     vsa_fp = VSAFingerprint(variant="EState", n_jobs=-1)
     feature_names = vsa_fp.get_feature_names_out()
 
-    assert len(feature_names) == vsa_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), vsa_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    # bins: https://github.com/rdkit/rdkit/blob/68672864c615f2ba75ddcbb40436fa107a611f34/rdkit/Chem/EState/EState_VSA.py#L62
-    # estateBins = [-0.390, 0.290, 0.717, 1.165, 1.540, 1.807, 2.05, 4.69, 9.17, 15.0]  # noqa: ERA001
-    assert feature_names[0] == "EState < -0.39"
-    assert feature_names[1] == "-0.39 <= EState < 0.29"
-    assert feature_names[-2] == "9.17 <= EState < 15.0"
-    assert feature_names[-1] == "EState >= 15.0"
+    assert_equal(feature_names[0], "EState < -0.39")
+    assert_equal(feature_names[1], "-0.39 <= EState < 0.29")
+    assert_equal(feature_names[-2], "9.17 <= EState < 15.0")
+    assert_equal(feature_names[-1], "EState >= 15.0")
 
 
 def test_vsa_all_feature_names():
     vsa_fp = VSAFingerprint(variant="all", n_jobs=-1)
     feature_names = vsa_fp.get_feature_names_out()
 
-    assert len(feature_names) == vsa_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), vsa_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
     assert all("SlogP" in name for name in feature_names[0:12])
     assert all("SMR" in name for name in feature_names[12:22])

--- a/tests/fingerprints/vsa.py
+++ b/tests/fingerprints/vsa.py
@@ -17,7 +17,7 @@ def test_vsa_fingerprint(mols_list):
 
     X_rdkit = np.column_stack((X_slogp, X_smr, X_peoe))
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(mols_list), 36)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -33,7 +33,7 @@ def test_vsa_fingerprint_with_estate(mols_list):
 
     X_rdkit = np.column_stack((X_slogp, X_smr, X_peoe, X_estate))
 
-    assert np.allclose(X_skfp, X_rdkit)
+    np.testing.assert_allclose(X_skfp, X_rdkit)
     assert X_skfp.shape == (len(mols_list), 47)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -64,7 +64,7 @@ def test_vsa_sparse_fingerprint(mols_list):
 
     X_rdkit = csr_array(np.column_stack((X_slogp, X_smr, X_peoe)))
 
-    assert np.allclose(X_skfp.data, X_rdkit.data)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data)
     assert X_skfp.shape == (len(mols_list), 36)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/whim.py
+++ b/tests/fingerprints/whim.py
@@ -17,7 +17,7 @@ def test_whim_fingerprint(mols_conformers_list):
     )
     X_rdkit = np.minimum(X_rdkit, whim_fp.clip_val)
 
-    assert np.allclose(X_skfp, X_rdkit, atol=1e-1)
+    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 114)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
@@ -34,7 +34,7 @@ def test_whim_sparse_fingerprint(mols_conformers_list):
     )
     X_rdkit = X_rdkit.minimum(whim_fp.clip_val)
 
-    assert np.allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
     assert X_skfp.shape == (len(mols_conformers_list), 114)
     assert np.issubdtype(X_skfp.dtype, np.floating)
 

--- a/tests/fingerprints/whim.py
+++ b/tests/fingerprints/whim.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from rdkit.Chem.rdMolDescriptors import CalcWHIM
 from scipy.sparse import csr_array
 
@@ -17,8 +18,8 @@ def test_whim_fingerprint(mols_conformers_list):
     )
     X_rdkit = np.minimum(X_rdkit, whim_fp.clip_val)
 
-    np.testing.assert_allclose(X_skfp, X_rdkit, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 114)
+    assert_allclose(X_skfp, X_rdkit, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 114))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -34,8 +35,8 @@ def test_whim_sparse_fingerprint(mols_conformers_list):
     )
     X_rdkit = X_rdkit.minimum(whim_fp.clip_val)
 
-    np.testing.assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
-    assert X_skfp.shape == (len(mols_conformers_list), 114)
+    assert_allclose(X_skfp.data, X_rdkit.data, atol=1e-1)
+    assert_equal(X_skfp.shape, (len(mols_conformers_list), 114))
     assert np.issubdtype(X_skfp.dtype, np.floating)
 
 
@@ -43,21 +44,21 @@ def test_whim_feature_names():
     whim_fp = WHIMFingerprint()
     feature_names = whim_fp.get_feature_names_out()
 
-    assert len(feature_names) == whim_fp.n_features_out
-    assert len(feature_names) == len(set(feature_names))
+    assert_equal(len(feature_names), whim_fp.n_features_out)
+    assert_equal(len(feature_names), len(set(feature_names)))
 
-    assert feature_names[0] == "unweighted axis 1 directional WHIM size"
-    assert feature_names[3] == "unweighted axis 1 directional WHIM shape"
-    assert feature_names[10] == "unweighted axis 3 directional WHIM density"
-    assert feature_names[11] == "atomic mass axis 1 directional WHIM size"
-    assert feature_names[22] == "van der Waals volume axis 1 directional WHIM size"
-    assert feature_names[33] == "electronegativity axis 1 directional WHIM size"
-    assert feature_names[44] == "polarizability axis 1 directional WHIM size"
-    assert feature_names[76] == "IState axis 3 directional WHIM density"
+    assert_equal(feature_names[0], "unweighted axis 1 directional WHIM size")
+    assert_equal(feature_names[3], "unweighted axis 1 directional WHIM shape")
+    assert_equal(feature_names[10], "unweighted axis 3 directional WHIM density")
+    assert_equal(feature_names[11], "atomic mass axis 1 directional WHIM size")
+    assert_equal(feature_names[22], "van der Waals volume axis 1 directional WHIM size")
+    assert_equal(feature_names[33], "electronegativity axis 1 directional WHIM size")
+    assert_equal(feature_names[44], "polarizability axis 1 directional WHIM size")
+    assert_equal(feature_names[76], "IState axis 3 directional WHIM density")
 
-    assert feature_names[77] == "unweighted global WHIM size"
-    assert feature_names[78] == "atomic mass global WHIM size"
-    assert feature_names[83] == "IState global WHIM size"
+    assert_equal(feature_names[77], "unweighted global WHIM size")
+    assert_equal(feature_names[78], "atomic mass global WHIM size")
+    assert_equal(feature_names[83], "IState global WHIM size")
 
     assert all(
         name.endswith("global WHIM size cross sums") for name in feature_names[84:91]
@@ -65,8 +66,8 @@ def test_whim_feature_names():
     assert feature_names[84].startswith("unweighted")
     assert feature_names[90].startswith("IState")
 
-    assert feature_names[91] == "unweighted global WHIM axial shape"
-    assert feature_names[92] == "atomic mass global WHIM axial shape"
+    assert_equal(feature_names[91], "unweighted global WHIM axial shape")
+    assert_equal(feature_names[92], "atomic mass global WHIM axial shape")
 
     assert all(name.endswith("global WHIM shape") for name in feature_names[93:100])
     assert feature_names[93].startswith("unweighted")

--- a/tests/metrics/auroc.py
+++ b/tests/metrics/auroc.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from sklearn.metrics import roc_auc_score
 
 from skfp.metrics import auroc_score
@@ -10,7 +11,7 @@ def test_auroc_score_sklearn_behavior():
     y_score = np.array([0.7, 0.1, 0.05])
     sklearn_auroc = roc_auc_score(y_true, y_score)
     skfp_auroc = auroc_score(y_true, y_score)
-    assert np.isclose(sklearn_auroc, skfp_auroc)
+    assert_allclose(sklearn_auroc, skfp_auroc)
 
 
 def test_auroc_score_y_true_constant_nan():
@@ -41,7 +42,7 @@ def test_auroc_score_y_true_constant_float():
     y_true = np.array([0, 0, 0])
     y_score = np.array([0.7, 0.1, 0.05])
     skfp_auroc = auroc_score(y_true, y_score, constant_target_behavior=0.5)
-    assert np.isclose(skfp_auroc, 0.5)
+    assert_allclose(skfp_auroc, 0.5)
 
     skfp_auroc = auroc_score(y_true, y_score, constant_target_behavior=1.0)
-    assert np.isclose(skfp_auroc, 1.0)
+    assert_allclose(skfp_auroc, 1.0)

--- a/tests/metrics/multioutput.py
+++ b/tests/metrics/multioutput.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.metrics import (
@@ -78,12 +79,7 @@ def test_multioutput_metrics_single_task_equivalence(
 
     single_task_value = single_task_metric(y_true, y_pred)
     multioutput_value = multioutput_metric(y_true, y_pred)
-    if not np.isclose(single_task_value, multioutput_value):
-        raise AssertionError(
-            f"{metric_name} values differ:"
-            f"single-task {single_task_value:.2f}, "
-            f"multioutput {multioutput_value:.2f}"
-        )
+    assert_allclose(single_task_value, multioutput_value)
 
 
 @pytest.mark.parametrize(
@@ -272,7 +268,7 @@ def test_skip_all_nan_column():
     score_without_nan = _safe_multioutput_metric(
         mean_squared_error, y_true[:, [0, 2]], y_pred[:, [0, 2]]
     )
-    assert np.isclose(score_with_nan, score_without_nan)
+    assert_allclose(score_with_nan, score_without_nan)
 
 
 def test_metrics_inputs_shapes():

--- a/tests/metrics/spearman.py
+++ b/tests/metrics/spearman.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 
 from skfp.metrics import spearman_correlation
 
@@ -8,8 +9,8 @@ def test_spearman_perfect_correlation():
     y_pred = list(range(1, 6))
     corr = spearman_correlation(y_true, y_pred)
     np_corr = spearman_correlation(np.array(y_true), np.array(y_pred))
-    assert np.isclose(corr, np_corr)
-    assert np.isclose(corr, 1.0)
+    assert_allclose(corr, np_corr)
+    assert_allclose(corr, 1.0)
 
 
 def test_spearman_perfect_anticorrelation():
@@ -17,8 +18,8 @@ def test_spearman_perfect_anticorrelation():
     y_pred = [5, 4, 3, 2, 1]
     corr = spearman_correlation(y_true, y_pred)
     np_corr = spearman_correlation(np.array(y_true), np.array(y_pred))
-    assert np.isclose(corr, np_corr)
-    assert np.isclose(corr, -1.0)
+    assert_allclose(corr, np_corr)
+    assert_allclose(corr, -1.0)
 
 
 def test_spearman_average_correlation():
@@ -26,15 +27,15 @@ def test_spearman_average_correlation():
     y_pred = [2, 1, 4, 3]
     corr = spearman_correlation(y_true, y_pred)
     np_corr = spearman_correlation(np.array(y_true), np.array(y_pred))
-    assert np.isclose(corr, np_corr)
-    assert np.isclose(corr, 0.6)
+    assert_allclose(corr, np_corr)
+    assert_allclose(corr, 0.6)
 
 
 def test_spearman_constant_input():
     y_true = list(range(5))
     y_pred = list(range(5))
     corr = spearman_correlation(y_true, y_pred)
-    assert np.isclose(corr, 1.0)
+    assert_allclose(corr, 1.0)
     assert np.isnan(spearman_correlation(y_true, y_pred, equal_values_result=np.nan))
 
 
@@ -42,4 +43,4 @@ def test_spearman_p_value():
     y_true = list(range(5))
     y_pred = list(range(1, 6))
     p_value = spearman_correlation(y_true, y_pred, return_p_value=True)
-    assert np.isclose(p_value, 0.0)
+    assert_allclose(p_value, 0.0)

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 
 from skfp.metrics import extract_pos_proba
 
@@ -10,7 +11,7 @@ def test_extract_pos_proba_single_task():
     predictions = np.random.rand(n_samples, 2)
     predictions = extract_pos_proba(predictions)
 
-    assert predictions.shape == (n_samples,)
+    assert_equal(predictions.shape, (n_samples,))
 
 
 def test_extract_pos_proba_multioutput():
@@ -20,7 +21,7 @@ def test_extract_pos_proba_multioutput():
     predictions = [np.random.rand(n_samples, 2) for _ in range(n_tasks)]
     predictions = extract_pos_proba(predictions)
 
-    assert predictions.shape == (n_samples, n_tasks)
+    assert_equal(predictions.shape, (n_samples, n_tasks))
 
 
 def test_extract_pos_proba_wrong_dimensions():

--- a/tests/metrics/virtual_screening.py
+++ b/tests/metrics/virtual_screening.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from skfp.metrics import bedroc_score, enrichment_factor, rie_score
 
@@ -14,7 +15,7 @@ def test_zero_enrichment_factor():
     y_test = [0] * 90 + [1] * 10
     y_score = [1] * 90 + [0] * 10
     ef = enrichment_factor(y_test, y_score)
-    assert np.isclose(ef, 0, atol=1e-4)
+    assert_allclose(ef, 0, atol=1e-4)
 
 
 def test_max_enrichment_factor():
@@ -25,7 +26,7 @@ def test_max_enrichment_factor():
     max_ef = len(y_test) / sum(y_test)
 
     ef = enrichment_factor(y_test, y_score)
-    assert np.isclose(ef, max_ef)
+    assert_allclose(ef, max_ef)
 
 
 def test_rie_score():
@@ -38,7 +39,7 @@ def test_zero_rie_score():
     y_test = [0] * 90 + [1] * 10
     y_score = [1] * 90 + [0] * 10
     rie = rie_score(y_test, y_score)
-    assert np.isclose(rie, 0, atol=1e-4)
+    assert_allclose(rie, 0, atol=1e-4)
 
 
 def test_max_rie_score():
@@ -51,7 +52,7 @@ def test_max_rie_score():
     max_rie = (N / n) * (1 - np.e ** (-alpha * n / N)) / (1 - np.e ** (-alpha))
 
     rie = rie_score(y_test, y_score, alpha)
-    assert np.isclose(rie, max_rie)
+    assert_allclose(rie, max_rie)
 
 
 def test_bedroc_score():
@@ -64,14 +65,14 @@ def test_zero_bedroc_score():
     y_test = [0] * 90 + [1] * 10
     y_score = [1] * 90 + [0] * 10
     bedroc = bedroc_score(y_test, y_score)
-    assert np.isclose(bedroc, 0, atol=1e-4)
+    assert_allclose(bedroc, 0, atol=1e-4)
 
 
 def test_max_bedroc_score():
     y_test = [0] * 90 + [1] * 10
     y_score = [0] * 90 + [1] * 10
     bedroc = bedroc_score(y_test, y_score)
-    assert np.isclose(bedroc, 1)
+    assert_allclose(bedroc, 1)
 
 
 @pytest.mark.parametrize("metric_func", [enrichment_factor, rie_score, bedroc_score])

--- a/tests/model_selection/hyperparam_search/grid_search.py
+++ b/tests/model_selection/hyperparam_search/grid_search.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from sklearn.dummy import DummyClassifier
 from sklearn.model_selection import GridSearchCV
 
@@ -18,6 +19,7 @@ def test_fp_estimator_grid_search(smallest_mols_list):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": [2, 3, 4]}
     estimator_cv = GridSearchCV(
@@ -30,19 +32,19 @@ def test_fp_estimator_grid_search(smallest_mols_list):
 
     y_pred = fp_cv.predict(smallest_mols_list)
     y_pred_proba = fp_cv.predict_proba(smallest_mols_list)
-    assert len(y_pred) == len(smallest_mols_list)
-    assert len(y_pred) == len(y_pred_proba)
+    assert_equal(len(y_pred), len(smallest_mols_list))
+    assert_equal(len(y_pred), len(y_pred_proba))
 
     X = fp_cv.transform(smallest_mols_list)
-    assert X.shape == (len(smallest_mols_list), fp.n_features_out)
+    assert_equal(X.shape, (len(smallest_mols_list), fp.n_features_out))
 
-    assert len(fp_cv.cv_results_) == 3
+    assert_equal(len(fp_cv.cv_results_), 3)
     assert isinstance(fp_cv.best_fp_, AtomPairFingerprint)
     assert isinstance(fp_cv.best_fp_params_, dict)
-    assert np.isclose(fp_cv.best_score_, len(pos_mols) / num_mols)
+    assert_allclose(fp_cv.best_score_, len(pos_mols) / num_mols)
 
     assert isinstance(fp_cv.best_estimator_cv_.best_estimator_, MockClassifier)
-    assert fp_cv.best_estimator_cv_.best_params_ == {"param1": 0, "param2": 0}
+    assert_equal(fp_cv.best_estimator_cv_.best_params_, {"param1": 0, "param2": 0})
 
 
 def test_fp_estimator_grid_search_verbose(smallest_mols_list, capsys):
@@ -50,6 +52,7 @@ def test_fp_estimator_grid_search_verbose(smallest_mols_list, capsys):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": [2, 3, 4]}
     estimator_cv = GridSearchCV(
@@ -75,6 +78,7 @@ def test_best_fp_caching(smallest_mols_list):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": [2, 3, 4]}
     estimator_cv = GridSearchCV(
@@ -93,4 +97,4 @@ def test_best_fp_caching(smallest_mols_list):
 
     assert fp_cv.best_fp_array_ is not None
     assert isinstance(fp_cv.best_fp_array_, np.ndarray)
-    assert fp_cv.best_fp_array_.shape == (num_mols, fp.n_features_out)
+    assert_equal(fp_cv.best_fp_array_.shape, (num_mols, fp.n_features_out))

--- a/tests/model_selection/hyperparam_search/randomized_selection.py
+++ b/tests/model_selection/hyperparam_search/randomized_selection.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 from sklearn.dummy import DummyClassifier
 from sklearn.model_selection import GridSearchCV
 
@@ -18,6 +19,7 @@ def test_fp_estimator_randomized_search(smallest_mols_list):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": list(range(2, 31))}
     estimator_cv = GridSearchCV(
@@ -32,19 +34,19 @@ def test_fp_estimator_randomized_search(smallest_mols_list):
 
     y_pred = fp_cv.predict(smallest_mols_list)
     y_pred_proba = fp_cv.predict_proba(smallest_mols_list)
-    assert len(y_pred) == len(smallest_mols_list)
-    assert len(y_pred) == len(y_pred_proba)
+    assert_equal(len(y_pred), len(smallest_mols_list))
+    assert_equal(len(y_pred), len(y_pred_proba))
 
     X = fp_cv.transform(smallest_mols_list)
-    assert X.shape == (len(smallest_mols_list), fp.n_features_out)
+    assert_equal(X.shape, (len(smallest_mols_list), fp.n_features_out))
 
-    assert len(fp_cv.cv_results_) == 10
+    assert_equal(len(fp_cv.cv_results_), 10)
     assert isinstance(fp_cv.best_fp_, AtomPairFingerprint)
     assert isinstance(fp_cv.best_fp_params_, dict)
-    assert np.isclose(fp_cv.best_score_, len(pos_mols) / num_mols)
+    assert_allclose(fp_cv.best_score_, len(pos_mols) / num_mols)
 
     assert isinstance(fp_cv.best_estimator_cv_.best_estimator_, MockClassifier)
-    assert fp_cv.best_estimator_cv_.best_params_ == {"param1": 0, "param2": 0}
+    assert_equal(fp_cv.best_estimator_cv_.best_params_, {"param1": 0, "param2": 0})
 
 
 def test_fp_estimator_randomized_search_verbose(smallest_mols_list, capsys):
@@ -52,6 +54,7 @@ def test_fp_estimator_randomized_search_verbose(smallest_mols_list, capsys):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": list(range(2, 31))}
     estimator_cv = GridSearchCV(
@@ -76,6 +79,7 @@ def test_best_fp_caching(smallest_mols_list):
     pos_mols = np.ones(num_mols // 2)
     neg_mols = np.zeros(num_mols - len(pos_mols))
     y = np.concatenate((pos_mols, neg_mols))
+
     fp = AtomPairFingerprint()
     fp_param_grid = {"max_distance": [2, 3, 4]}
     estimator_cv = GridSearchCV(
@@ -95,4 +99,4 @@ def test_best_fp_caching(smallest_mols_list):
 
     assert fp_cv.best_fp_array_ is not None
     assert isinstance(fp_cv.best_fp_array_, np.ndarray)
-    assert fp_cv.best_fp_array_.shape == (num_mols, fp.n_features_out)
+    assert_equal(fp_cv.best_fp_array_.shape, (num_mols, fp.n_features_out))

--- a/tests/model_selection/splitters/butina_split.py
+++ b/tests/model_selection/splitters/butina_split.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit import Chem
 from rdkit.Chem import Mol
 
@@ -13,89 +14,76 @@ from skfp.preprocessing import MolFromSmilesTransformer
 
 @pytest.fixture
 def varied_mols() -> list[str]:
-    # those molecules are quite varied, so they get high Tanimoto distance
-    # and thus constitute separate centroids for Taylor-Butina clustering
+    # diverse set of molecules for clustering
     return [
-        # benzene
-        "c1ccccc1",
-        # ibuprofen
-        "CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O",
-        # caffeine
-        "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
-        # sodium chloride (salt)
-        "[Na+].[Cl-]",
-        # nicotine
-        "c1ncccc1[C@@H]2CCCN2C",
-        # Venlafaxine
-        "OC2(C(c1ccc(OC)cc1)CN(C)C)CCCCC2",
-        # Chlordiazepoxide
-        "ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1",
-        # Buspirone
-        "O=C1CC2(CCCC2)CC(=O)N1CCCCN1CCN(c2ncccn2)CC1",
-        # Paraldehyde
-        "CC1OC(C)OC(C)O1",
-        # Quetiapine
-        r"N\1=C(\c3c(Sc2c/1cccc2)cccc3)N4CCN(CCOCCO)CC4",
+        "c1ccccc1",  # benzene
+        "CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O",  # ibuprofen
+        "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",  # caffeine
+        "[Na+].[Cl-]",  # sodium chloride
+        "c1ncccc1[C@@H]2CCCN2C",  # nicotine
+        "OC2(C(c1ccc(OC)cc1)CN(C)C)CCCCC2",  # venlafaxine
+        "ClC1=CC2=C(N=C(NC)C[N+]([O-])=C2C3=CC=CC=C3)C=C1",  # chlordiazepoxide
+        "O=C1CC2(CCCC2)CC(=O)N1CCCCN1CCN(c2ncccn2)CC1",  # buspirone
+        "CC1OC(C)OC(C)O1",  # paraldehyde
+        r"N\1=C(\c3c(Sc2c/1cccc2)cccc3)N4CCN(CCOCCO)CC4",  # quetiapine
     ]
 
 
 def test_butina_train_test_split_default(varied_mols):
     train, test = butina_train_test_split(varied_mols)
-    assert len(train) == 8
-    assert len(test) == 2
+    assert_equal(len(train), 8)
+    assert_equal(len(test), 2)
 
 
 def test_butina_train_test_split_custom_sizes(varied_mols):
     train, test = butina_train_test_split(varied_mols, train_size=0.7, test_size=0.3)
-    assert len(train) == 7
-    assert len(test) == 3
+    assert_equal(len(train), 7)
+    assert_equal(len(test), 3)
 
 
 def test_train_test_split_total_molecule_count(varied_mols):
     train_split, test_split = butina_train_test_split(
         varied_mols, train_size=0.8, test_size=0.2
     )
-    assert len(train_split) + len(test_split) == len(varied_mols)
-    assert len(train_split) == 8
-    assert len(test_split) == 2
+    assert_equal(len(train_split) + len(test_split), len(varied_mols))
+    assert_equal(len(train_split), 8)
+    assert_equal(len(test_split), 2)
 
 
 def test_train_valid_test_split_total_molecule_count(varied_mols):
     train_split, valid_split, test_split = butina_train_valid_test_split(
         varied_mols, train_size=0.8, valid_size=0.1, test_size=0.1
     )
-
-    assert len(train_split) + len(valid_split) + len(test_split) == len(varied_mols)
-    assert len(train_split) == 8
-    assert len(valid_split) == 1
-    assert len(test_split) == 1
+    assert_equal(
+        len(train_split) + len(valid_split) + len(test_split), len(varied_mols)
+    )
+    assert_equal(len(train_split), 8)
+    assert_equal(len(valid_split), 1)
+    assert_equal(len(test_split), 1)
 
 
 def test_test_split_smaller_than_train_split(varied_mols):
     train_split, test_split = butina_train_test_split(
         varied_mols, train_size=0.7, test_size=0.3
     )
-
     assert len(train_split) > len(test_split)
-    assert len(train_split) == 7
-    assert len(test_split) == 3
+    assert_equal(len(train_split), 7)
+    assert_equal(len(test_split), 3)
 
 
 def test_train_split_larger_than_valid_and_test_splits(varied_mols):
     train_split, valid_split, test_split = butina_train_valid_test_split(
         varied_mols, train_size=0.7, valid_size=0.2, test_size=0.1
     )
-
-    assert len(train_split) > len(valid_split)
-    assert len(valid_split) > len(test_split)
-    assert len(train_split) == 7
-    assert len(valid_split) == 2
-    assert len(test_split) == 1
+    assert len(train_split) > len(valid_split) > len(test_split)
+    assert_equal(len(train_split), 7)
+    assert_equal(len(valid_split), 2)
+    assert_equal(len(test_split), 1)
 
 
 def test_butina_creation_total_count(varied_mols):
-    butinas = _create_clusters(varied_mols)
-    assert len(butinas) <= len(varied_mols)
+    clusters = _create_clusters(varied_mols)
+    assert len(clusters) <= len(varied_mols)
 
 
 def test_butina_count_for_benzodiazepines():
@@ -106,20 +94,20 @@ def test_butina_count_for_benzodiazepines():
     ]
     mols = MolFromSmilesTransformer().transform(smiles_list)
 
-    butinas = _create_clusters(mols)
-    assert len(butinas) == 1
+    clusters = _create_clusters(mols)
+    assert_equal(len(clusters), 1)
 
 
 def test_butina_train_test_split_returns_molecules(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     train_set, test_set = butina_train_test_split(mols, return_indices=False)
 
-    assert all(isinstance(train, Mol) for train in train_set)
-    assert all(isinstance(test, Mol) for test in test_set)
+    assert all(isinstance(m, Mol) for m in train_set)
+    assert all(isinstance(m, Mol) for m in test_set)
 
 
 def test_butina_train_test_split_return_indices(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     train_idxs, test_idxs = butina_train_test_split(mols, return_indices=True)
 
     assert all(isinstance(idx, int) for idx in train_idxs)
@@ -127,18 +115,18 @@ def test_butina_train_test_split_return_indices(varied_mols):
 
 
 def test_butina_train_valid_test_split_returns_molecules(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     train_set, valid_set, test_set = butina_train_valid_test_split(
         mols, return_indices=False
     )
 
-    assert all(isinstance(train, Mol) for train in train_set)
-    assert all(isinstance(valid, Mol) for valid in valid_set)
-    assert all(isinstance(test, Mol) for test in test_set)
+    assert all(isinstance(m, Mol) for m in train_set)
+    assert all(isinstance(m, Mol) for m in valid_set)
+    assert all(isinstance(m, Mol) for m in test_set)
 
 
 def test_butina_train_valid_test_split_return_indices(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     train_idxs, valid_idxs, test_idxs = butina_train_valid_test_split(
         mols, return_indices=True
     )
@@ -149,45 +137,42 @@ def test_butina_train_valid_test_split_return_indices(varied_mols):
 
 
 def test_butina_train_test_split_with_additional_data(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     labels = np.ones(len(varied_mols))
     train_mols, test_mols, train_labels, test_labels = butina_train_test_split(
         mols, labels
     )
 
-    assert len(train_mols) == len(train_labels)
-    assert len(test_mols) == len(test_labels)
+    assert_equal(len(train_mols), len(train_labels))
+    assert_equal(len(test_mols), len(test_labels))
 
 
 def test_butina_train_valid_test_split_with_additional_data(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     labels = np.ones(len(varied_mols))
-    train_mols, valid_mols, test_mols, train_labels, valid_labels, test_labels = (
-        butina_train_valid_test_split(mols, labels)
-    )
+    (
+        train_mols,
+        valid_mols,
+        test_mols,
+        train_labels,
+        valid_labels,
+        test_labels,
+    ) = butina_train_valid_test_split(mols, labels)
 
-    assert len(train_mols) == len(train_labels)
-    assert len(valid_mols) == len(valid_labels)
-    assert len(test_mols) == len(test_labels)
+    assert_equal(len(train_mols), len(train_labels))
+    assert_equal(len(valid_mols), len(valid_labels))
+    assert_equal(len(test_mols), len(test_labels))
 
 
 def test_empty_train_subset_raises_an_error_train_test():
     smiles_list = ["C1CCCC(C2CC2)CC1"]
-
-    with pytest.raises(
-        ValueError,
-        match="the resulting train set will be empty",
-    ):
+    with pytest.raises(ValueError, match="the resulting train set will be empty"):
         butina_train_test_split(data=smiles_list)
 
 
 def test_empty_train_subset_raises_an_error_train_valid_test():
     smiles_list = ["C1CCCC(C2CC2)CC1", "c1n[nH]cc1C1CCCCCC1"]
-
-    with pytest.raises(
-        ValueError,
-        match="one of the sets will be empty",
-    ):
+    with pytest.raises(ValueError, match="one of the sets will be empty"):
         butina_train_valid_test_split(data=smiles_list)
 
 

--- a/tests/model_selection/splitters/maxmin_split.py
+++ b/tests/model_selection/splitters/maxmin_split.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from rdkit import Chem
 from rdkit.Chem import Mol
 
@@ -28,209 +29,174 @@ def varied_mols() -> list[str]:
 
 
 def test_maxmin_split_size(varied_mols):
-    train_set, test_set = maxmin_train_test_split(
-        varied_mols, train_size=0.7, test_size=0.3
-    )
+    train, test = maxmin_train_test_split(varied_mols, train_size=0.7, test_size=0.3)
+    assert_equal(len(train), 7)
+    assert_equal(len(test), 3)
 
-    assert len(train_set) == 7
-    assert len(test_set) == 3
-
-    train_set, test_set = maxmin_train_test_split(
-        varied_mols, train_size=0.6, test_size=0.4
-    )
-
-    assert len(train_set) == 6
-    assert len(test_set) == 4
+    train, test = maxmin_train_test_split(varied_mols, train_size=0.6, test_size=0.4)
+    assert_equal(len(train), 6)
+    assert_equal(len(test), 4)
 
 
 def test_maxmin_valid_split_size(varied_mols):
-    train_set, valid_set, test_set = maxmin_train_valid_test_split(
+    train, valid, test = maxmin_train_valid_test_split(
         varied_mols, train_size=0.7, test_size=0.2, valid_size=0.1
     )
+    assert_equal(len(train), 7)
+    assert_equal(len(test), 2)
+    assert_equal(len(valid), 1)
 
-    assert len(train_set) == 7
-    assert len(test_set) == 2
-    assert len(valid_set) == 1
-
-    train_set, valid_set, test_set = maxmin_train_valid_test_split(
+    train, valid, test = maxmin_train_valid_test_split(
         varied_mols, train_size=0.5, test_size=0.2, valid_size=0.3
     )
-
-    assert len(train_set) == 5
-    assert len(test_set) == 2
-    assert len(valid_set) == 3
+    assert_equal(len(train), 5)
+    assert_equal(len(test), 2)
+    assert_equal(len(valid), 3)
 
 
 def test_seed_consistency_train_valid_test_split(varied_mols):
-    train_set_1, valid_set_1, test_set_1 = maxmin_train_valid_test_split(
+    t1, v1, s1 = maxmin_train_valid_test_split(
         varied_mols, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
     )
-
-    train_set_2, valid_set_2, test_set_2 = maxmin_train_valid_test_split(
+    t2, v2, s2 = maxmin_train_valid_test_split(
         varied_mols, train_size=0.7, valid_size=0.1, test_size=0.2, random_state=0
     )
-
-    assert train_set_1 == train_set_2
-    assert valid_set_1 == valid_set_2
-    assert test_set_1 == test_set_2
+    assert_equal(t1, t2)
+    assert_equal(v1, v2)
+    assert_equal(s1, s2)
 
 
 def test_seed_consistency_train_test_split(varied_mols):
-    train_set_1, test_set_1 = maxmin_train_test_split(
+    t1, s1 = maxmin_train_test_split(
         varied_mols, train_size=0.7, test_size=0.3, random_state=0
     )
-
-    train_set_2, test_set_2 = maxmin_train_test_split(
+    t2, s2 = maxmin_train_test_split(
         varied_mols, train_size=0.7, test_size=0.3, random_state=0
     )
-
-    assert train_set_1 == train_set_2
-    assert test_set_1 == test_set_2
+    assert_equal(t1, t2)
+    assert_equal(s1, s2)
 
 
 def test_maxmin_train_test_split_return_molecules(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
-    train_set, test_set = maxmin_train_test_split(mols, train_size=0.7, test_size=0.3)
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
+    train, test = maxmin_train_test_split(mols, train_size=0.7, test_size=0.3)
 
-    assert all(isinstance(train, Mol) for train in train_set)
-    assert all(isinstance(test, Mol) for test in test_set)
-
-    assert len(train_set + test_set) == len(mols)
+    assert all(isinstance(m, Mol) for m in train)
+    assert all(isinstance(m, Mol) for m in test)
+    assert_equal(len(train) + len(test), len(mols))
 
 
 def test_maxmin_train_valid_test_split_returns_molecules(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
-    train_set, valid_set, test_set = maxmin_train_valid_test_split(
-        mols,
-        train_size=0.7,
-        test_size=0.2,
-        valid_size=0.1,
-        return_indices=False,
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
+    train, valid, test = maxmin_train_valid_test_split(
+        mols, train_size=0.7, test_size=0.2, valid_size=0.1, return_indices=False
     )
 
-    assert all(isinstance(train, Mol) for train in train_set)
-    assert all(isinstance(valid, Mol) for valid in valid_set)
-    assert all(isinstance(test, Mol) for test in test_set)
-
-    assert len(train_set + valid_set + test_set) == len(mols)
+    assert all(isinstance(m, Mol) for m in train)
+    assert all(isinstance(m, Mol) for m in valid)
+    assert all(isinstance(m, Mol) for m in test)
+    assert_equal(len(train) + len(valid) + len(test), len(mols))
 
 
 def test_maxmin_train_test_split_return_indices(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
-    train_set, test_set = maxmin_train_test_split(
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
+    train, test = maxmin_train_test_split(
         mols, train_size=0.7, test_size=0.3, return_indices=True
     )
 
-    assert all(isinstance(train, int) for train in train_set)
-    assert all(isinstance(test, int) for test in test_set)
-
-    assert len(set(train_set) | set(test_set)) == len(varied_mols)
+    assert all(isinstance(idx, int) for idx in train)
+    assert all(isinstance(idx, int) for idx in test)
+    assert_equal(len(set(train) | set(test)), len(varied_mols))
 
 
 def test_maxmin_train_valid_test_split_returns_indices(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
-    train_set, valid_set, test_set = maxmin_train_valid_test_split(
-        mols,
-        train_size=0.7,
-        test_size=0.2,
-        valid_size=0.1,
-        return_indices=True,
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
+    train, valid, test = maxmin_train_valid_test_split(
+        mols, train_size=0.7, test_size=0.2, valid_size=0.1, return_indices=True
     )
 
-    assert all(isinstance(train, int) for train in train_set)
-    assert all(isinstance(valid, int) for valid in valid_set)
-    assert all(isinstance(test, int) for test in test_set)
-
-    assert len(set(train_set) | set(valid_set) | set(test_set)) == len(varied_mols)
+    assert all(isinstance(idx, int) for idx in train)
+    assert all(isinstance(idx, int) for idx in valid)
+    assert all(isinstance(idx, int) for idx in test)
+    assert_equal(len(set(train) | set(valid) | set(test)), len(varied_mols))
 
 
 def test_maxmin_train_test_split_with_additional_data(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     labels = np.ones(len(varied_mols))
     train_mols, test_mols, train_labels, test_labels = maxmin_train_test_split(
         mols, labels
     )
-
-    assert len(train_mols) == len(train_labels)
-    assert len(test_mols) == len(test_labels)
+    assert_equal(len(train_mols), len(train_labels))
+    assert_equal(len(test_mols), len(test_labels))
 
 
 def test_maxmin_train_valid_test_split_with_additional_data(varied_mols):
-    mols = [Chem.MolFromSmiles(smiles) for smiles in varied_mols]
+    mols = [Chem.MolFromSmiles(smi) for smi in varied_mols]
     labels = np.ones(len(varied_mols))
-    train_mols, valid_mols, test_mols, train_labels, valid_labels, test_labels = (
-        maxmin_train_valid_test_split(mols, labels)
+    train, valid, test, y_train, y_valid, y_test = maxmin_train_valid_test_split(
+        mols, labels
     )
-
-    assert len(train_mols) == len(train_labels)
-    assert len(valid_mols) == len(valid_labels)
-    assert len(test_mols) == len(test_labels)
+    assert_equal(len(train), len(y_train))
+    assert_equal(len(valid), len(y_valid))
+    assert_equal(len(test), len(y_test))
 
 
 def test_maxmin_stratified_train_test_split(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
     mols_train, mols_test, y_train, y_test = maxmin_stratified_train_test_split(
         mols_list, labels, train_size=0.7, test_size=0.3
     )
 
-    assert len(mols_train) == int(0.7 * len(mols_list))
-    assert len(mols_test) == int(0.3 * len(mols_list))
-    assert len(mols_train + mols_test) == len(mols_list)
+    assert_equal(len(mols_train), int(0.7 * len(mols_list)))
+    assert_equal(len(mols_test), int(0.3 * len(mols_list)))
+    assert_equal(len(mols_train) + len(mols_test), len(mols_list))
 
-    assert len(mols_train) == len(y_train)
-    assert len(mols_test) == len(y_test)
+    assert_equal(len(mols_train), len(y_train))
+    assert_equal(len(mols_test), len(y_test))
 
-    assert np.isclose(y_train.mean(), 0.5)
-    assert np.isclose(y_test.mean(), 0.5)
-    assert len(np.concatenate((y_train, y_test))) == len(mols_list)
+    assert_allclose(y_train.mean(), 0.5)
+    assert_allclose(y_test.mean(), 0.5)
+    assert_equal(len(np.concatenate((y_train, y_test))), len(mols_list))
 
 
 def test_maxmin_stratified_train_valid_test_split(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
     mols_train, mols_valid, mols_test, y_train, y_valid, y_test = (
         maxmin_stratified_train_valid_test_split(
-            mols_list,
-            labels,
-            train_size=0.7,
-            valid_size=0.1,
-            test_size=0.2,
+            mols_list, labels, train_size=0.7, valid_size=0.1, test_size=0.2
         )
     )
 
-    assert len(mols_train) == int(0.7 * len(mols_list))
-    assert len(mols_valid) == int(0.1 * len(mols_list))
-    assert len(mols_test) == int(0.2 * len(mols_list))
-    assert len(mols_train + mols_valid + mols_test) == len(mols_list)
+    assert_equal(len(mols_train), int(0.7 * len(mols_list)))
+    assert_equal(len(mols_valid), int(0.1 * len(mols_list)))
+    assert_equal(len(mols_test), int(0.2 * len(mols_list)))
+    assert_equal(len(mols_train) + len(mols_valid) + len(mols_test), len(mols_list))
 
-    assert len(mols_train) == len(y_train)
-    assert len(mols_valid) == len(y_valid)
-    assert len(mols_test) == len(y_test)
+    assert_equal(len(mols_train), len(y_train))
+    assert_equal(len(mols_valid), len(y_valid))
+    assert_equal(len(mols_test), len(y_test))
 
-    assert np.isclose(y_train.mean(), 0.5)
-    assert np.isclose(y_valid.mean(), 0.5)
-    assert np.isclose(y_test.mean(), 0.5)
-    assert len(np.concatenate((y_train, y_valid, y_test))) == len(mols_list)
+    assert_allclose(y_train.mean(), 0.5)
+    assert_allclose(y_valid.mean(), 0.5)
+    assert_allclose(y_test.mean(), 0.5)
+    assert_equal(len(np.concatenate((y_train, y_valid, y_test))), len(mols_list))
 
 
 def test_maxmin_stratified_train_test_split_return_indices(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-
-    train_set, test_set, train_labels, test_labels = maxmin_stratified_train_test_split(
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
+    train, test, y_train, y_test = maxmin_stratified_train_test_split(
         mols_list, labels, train_size=0.7, test_size=0.3, return_indices=True
     )
 
-    assert all(isinstance(train, int) for train in train_set)
-    assert all(isinstance(test, int) for test in test_set)
-
-    assert len(set(train_set) | set(test_set)) == len(mols_list)
+    assert all(isinstance(idx, int) for idx in train)
+    assert all(isinstance(idx, int) for idx in test)
+    assert_equal(len(set(train) | set(test)), len(mols_list))
 
 
 def test_maxmin_stratified_train_valid_test_split_returns_indices(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-
-    train_set, valid_set, test_set, train_labels, valid_labels, test_labels = (
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
+    train, valid, test, y_train, y_valid, y_test = (
         maxmin_stratified_train_valid_test_split(
             mols_list,
             labels,
@@ -241,55 +207,48 @@ def test_maxmin_stratified_train_valid_test_split_returns_indices(mols_list):
         )
     )
 
-    assert all(isinstance(train, int) for train in train_set)
-    assert all(isinstance(valid, int) for valid in valid_set)
-    assert all(isinstance(test, int) for test in test_set)
-
-    assert len(set(train_set) | set(valid_set) | set(test_set)) == len(mols_list)
+    assert all(isinstance(idx, int) for idx in train)
+    assert all(isinstance(idx, int) for idx in valid)
+    assert all(isinstance(idx, int) for idx in test)
+    assert_equal(len(set(train) | set(valid) | set(test)), len(mols_list))
 
 
 def test_maxmin_stratified_train_test_split_with_additional_data(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-    additional_data = ["a"] * len(mols_list)
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
+    extra = ["a"] * len(mols_list)
 
-    (
-        train_mols,
-        test_mols,
-        train_labels,
-        test_labels,
-        train_additional_data,
-        test_additional_data,
-    ) = maxmin_stratified_train_test_split(
-        mols_list, labels, additional_data, test_size=0.2
+    train_mols, test_mols, y_train, y_test, extra_train, extra_test = (
+        maxmin_stratified_train_test_split(mols_list, labels, extra, test_size=0.2)
     )
 
-    assert len(train_mols) == len(train_labels) == len(train_additional_data)
-    assert len(test_mols) == len(test_labels) == len(test_additional_data)
+    assert_equal(len(train_mols), len(y_train))
+    assert_equal(len(test_mols), len(y_test))
+    assert_equal(len(train_mols), len(extra_train))
+    assert_equal(len(test_mols), len(extra_test))
 
 
 def test_maxmin_stratified_train_valid_test_split_with_additional_data(mols_list):
-    labels = [0] * int(0.5 * len(mols_list)) + [1] * int(0.5 * len(mols_list))
-    additional_data = ["a"] * len(mols_list)
+    labels = [0] * (len(mols_list) // 2) + [1] * (len(mols_list) // 2)
+    extra = ["a"] * len(mols_list)
 
     (
         train_mols,
         valid_mols,
         test_mols,
-        train_labels,
-        valid_labels,
-        test_labels,
-        train_additional_data,
-        valid_additional_data,
-        test_additional_data,
+        y_train,
+        y_valid,
+        y_test,
+        extra_train,
+        extra_valid,
+        extra_test,
     ) = maxmin_stratified_train_valid_test_split(
-        mols_list,
-        labels,
-        additional_data,
-        train_size=0.7,
-        valid_size=0.1,
-        test_size=0.2,
+        mols_list, labels, extra, train_size=0.7, valid_size=0.1, test_size=0.2
     )
 
-    assert len(train_mols) == len(train_labels) == len(train_additional_data)
-    assert len(valid_mols) == len(valid_labels) == len(valid_additional_data)
-    assert len(test_mols) == len(test_labels) == len(test_additional_data)
+    assert_equal(len(train_mols), len(y_train))
+    assert_equal(len(valid_mols), len(y_valid))
+    assert_equal(len(test_mols), len(y_test))
+
+    assert_equal(len(train_mols), len(extra_train))
+    assert_equal(len(valid_mols), len(extra_valid))
+    assert_equal(len(test_mols), len(extra_test))

--- a/tests/model_selection/splitters/randomized_scaffold_split.py
+++ b/tests/model_selection/splitters/randomized_scaffold_split.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 from rdkit import Chem
 from rdkit.Chem import Mol
 
@@ -52,7 +53,7 @@ def smiles_ten_scaffolds() -> list[str]:
 
 def test_randomized_scaffold_creation_total_count(all_molecules):
     randomized_scaffolds = _create_scaffold_sets(all_molecules)
-    assert len(randomized_scaffolds) <= len(all_molecules)
+    assert_equal(len(randomized_scaffolds) <= len(all_molecules), True)
 
 
 def test_no_ring_molecules():
@@ -60,7 +61,7 @@ def test_no_ring_molecules():
     mols = MolFromSmilesTransformer().transform(smiles)
 
     randomized_scaffolds = _create_scaffold_sets(mols)
-    assert len(randomized_scaffolds) == 1
+    assert_equal(len(randomized_scaffolds), 1)
 
 
 def test_randomized_scaffold_count_for_benzodiazepines():
@@ -72,7 +73,7 @@ def test_randomized_scaffold_count_for_benzodiazepines():
     mols = MolFromSmilesTransformer().transform(smiles)
 
     randomized_scaffolds = _create_scaffold_sets(mols)
-    assert len(randomized_scaffolds) == 1
+    assert_equal(len(randomized_scaffolds), 1)
 
 
 def test_randomized_scaffold_count_for_xanthines():
@@ -85,12 +86,11 @@ def test_randomized_scaffold_count_for_xanthines():
     mols = MolFromSmilesTransformer().transform(smiles)
 
     randomized_scaffolds = _create_scaffold_sets(mols)
-    assert len(randomized_scaffolds) == 1
+    assert_equal(len(randomized_scaffolds), 1)
 
 
 def test_csk_high_degree_atoms():
     smiles = ["O=[U]=O", "F[U](F)(F)(F)(F)F"]
-
     randomized_scaffold_train_test_split(smiles, random_state=0, use_csk=True)
 
 
@@ -130,94 +130,74 @@ def test_seed_consistency_train_test_split(all_molecules):
     train_set_1, test_set_1 = randomized_scaffold_train_test_split(
         all_molecules, random_state=0
     )
-
     train_set_2, test_set_2 = randomized_scaffold_train_test_split(
         all_molecules, random_state=0
     )
 
-    assert train_set_1 == train_set_2
-    assert test_set_1 == test_set_2
+    assert_equal(train_set_1, train_set_2)
+    assert_equal(test_set_1, test_set_2)
 
 
-def test_seed_consistency_train_valid__test_split(all_molecules):
+def test_seed_consistency_train_valid_test_split(all_molecules):
     train_set_1, valid_set_1, test_set_1 = randomized_scaffold_train_valid_test_split(
         all_molecules, random_state=0
     )
-
     train_set_2, valid_set_2, test_set_2 = randomized_scaffold_train_valid_test_split(
         all_molecules, random_state=0
     )
 
-    assert train_set_1 == train_set_2
-    assert valid_set_1 == valid_set_2
-    assert test_set_1 == test_set_2
+    assert_equal(train_set_1, train_set_2)
+    assert_equal(valid_set_1, valid_set_2)
+    assert_equal(test_set_1, test_set_2)
 
 
-def test_train_test_split_properly_splits_csk_with_ints(
-    smiles_ten_scaffolds,
-):
+def test_train_test_split_properly_splits_csk_with_ints(smiles_ten_scaffolds):
     train_set, test_set = randomized_scaffold_train_test_split(
         data=smiles_ten_scaffolds, train_size=7, test_size=3, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(test_set) == 3
+    assert_equal(len(train_set), 7)
+    assert_equal(len(test_set), 3)
 
 
-def test_train_test_split_properly_splits_csk_with_floats(
-    smiles_ten_scaffolds,
-):
+def test_train_test_split_properly_splits_csk_with_floats(smiles_ten_scaffolds):
     train_set, test_set = randomized_scaffold_train_test_split(
-        data=smiles_ten_scaffolds,
-        train_size=0.7,
-        test_size=0.3,
-        use_csk=True,
+        data=smiles_ten_scaffolds, train_size=0.7, test_size=0.3, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(test_set) == 3
+    assert_equal(len(train_set), 7)
+    assert_equal(len(test_set), 3)
 
 
-def test_train_valid_test_split_properly_splits_csk_with_ints(
-    smiles_ten_scaffolds,
-):
+def test_train_valid_test_split_properly_splits_csk_with_ints(smiles_ten_scaffolds):
     train_set, valid_set, test_set = randomized_scaffold_train_valid_test_split(
-        data=smiles_ten_scaffolds,
-        train_size=7,
-        valid_size=2,
-        test_size=1,
-        use_csk=True,
+        data=smiles_ten_scaffolds, train_size=7, valid_size=2, test_size=1, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(valid_set) == 2
-    assert len(test_set) == 1
+    assert_equal(len(train_set), 7)
+    assert_equal(len(valid_set), 2)
+    assert_equal(len(test_set), 1)
 
 
-def test_train_valid_test_split_properly_splits_csk_with_floats(
-    smiles_ten_scaffolds,
-):
-    train_set, valid_size, test_set = randomized_scaffold_train_valid_test_split(
+def test_train_valid_test_split_properly_splits_csk_with_floats(smiles_ten_scaffolds):
+    train_set, valid_set, test_set = randomized_scaffold_train_valid_test_split(
         data=smiles_ten_scaffolds,
         train_size=0.7,
         valid_size=0.2,
         test_size=0.1,
         use_csk=True,
     )
-    assert len(train_set) == 7
-    assert len(valid_size) == 2
-    assert len(test_set) == 1
+    assert_equal(len(train_set), 7)
+    assert_equal(len(valid_set), 2)
+    assert_equal(len(test_set), 1)
 
 
 def test_randomized_scaffold_train_test_split_return_indices(all_molecules):
     train_size = 0.6
     test_size = 0.4
-    result = randomized_scaffold_train_test_split(
+    train_idxs, test_idxs = randomized_scaffold_train_test_split(
         all_molecules, train_size=train_size, test_size=test_size, return_indices=True
     )
 
-    train_idxs, test_idxs = result
-
     assert isinstance(train_idxs, list)
     assert isinstance(test_idxs, list)
-
     assert all(isinstance(idx, int) for idx in train_idxs)
     assert all(isinstance(idx, int) for idx in test_idxs)
 
@@ -227,29 +207,22 @@ def test_train_test_split_with_additional_data(smiles_ten_scaffolds):
     train_set, test_set, train_data, test_data = randomized_scaffold_train_test_split(
         smiles_ten_scaffolds, additional_data
     )
-    assert len(train_set) == 8
-    assert len(test_set) == 2
-
-    assert len(train_data) == 8
-    assert len(test_data) == 2
+    assert_equal(len(train_set), 8)
+    assert_equal(len(test_set), 2)
+    assert_equal(len(train_data), 8)
+    assert_equal(len(test_data), 2)
 
 
 def test_train_valid_test_split_with_additional_data(smiles_ten_scaffolds):
     additional_data = list(range(len(smiles_ten_scaffolds)))
-    (
-        train_set,
-        valid_set,
-        test_set,
-        train_data,
-        valid_data,
-        test_data,
-    ) = randomized_scaffold_train_valid_test_split(
-        smiles_ten_scaffolds, additional_data
+    train_set, valid_set, test_set, train_data, valid_data, test_data = (
+        randomized_scaffold_train_valid_test_split(
+            smiles_ten_scaffolds, additional_data
+        )
     )
-    assert len(train_set) == 8
-    assert len(valid_set) == 1
-    assert len(test_set) == 1
-
-    assert len(train_data) == 8
-    assert len(valid_data) == 1
-    assert len(test_data) == 1
+    assert_equal(len(train_set), 8)
+    assert_equal(len(valid_set), 1)
+    assert_equal(len(test_set), 1)
+    assert_equal(len(train_data), 8)
+    assert_equal(len(valid_data), 1)
+    assert_equal(len(test_data), 1)

--- a/tests/model_selection/splitters/scaffold_split.py
+++ b/tests/model_selection/splitters/scaffold_split.py
@@ -1,4 +1,5 @@
 import pytest
+from numpy.testing import assert_equal
 from rdkit import Chem
 from rdkit.Chem import Mol
 
@@ -43,25 +44,25 @@ def smiles_ten_scaffolds() -> list[str]:
 
 def test_scaffold_train_test_split_default(all_molecules):
     train, test = scaffold_train_test_split(all_molecules)
-    assert len(train) == 8
-    assert len(test) == 2
+    assert_equal(len(train), 8)
+    assert_equal(len(test), 2)
 
 
 def test_scaffold_train_test_split_custom_sizes(all_molecules):
     train, test = scaffold_train_test_split(
         all_molecules, train_size=0.7, test_size=0.3
     )
-    assert len(train) == 7
-    assert len(test) == 3
+    assert_equal(len(train), 7)
+    assert_equal(len(test), 3)
 
 
 def test_train_test_split_total_molecule_count(all_molecules):
     train_split, test_split = scaffold_train_test_split(
         all_molecules, train_size=0.8, test_size=0.2
     )
-    assert len(train_split) + len(test_split) == len(all_molecules)
-    assert len(train_split) == 8
-    assert len(test_split) == 2
+    assert_equal(len(train_split) + len(test_split), len(all_molecules))
+    assert_equal(len(train_split), 8)
+    assert_equal(len(test_split), 2)
 
 
 def test_train_valid_test_split_total_molecule_count(all_molecules):
@@ -69,32 +70,32 @@ def test_train_valid_test_split_total_molecule_count(all_molecules):
         all_molecules, train_size=0.8, valid_size=0.1, test_size=0.1
     )
 
-    assert len(train_split) + len(valid_split) + len(test_split) == len(all_molecules)
-    assert len(train_split) == 8
-    assert len(valid_split) == 1
-    assert len(test_split) == 1
+    assert_equal(
+        len(train_split) + len(valid_split) + len(test_split), len(all_molecules)
+    )
+    assert_equal(len(train_split), 8)
+    assert_equal(len(valid_split), 1)
+    assert_equal(len(test_split), 1)
 
 
 def test_test_split_smaller_than_train_split(all_molecules):
     train_split, test_split = scaffold_train_test_split(
         all_molecules, train_size=0.7, test_size=0.3
     )
-
     assert len(train_split) > len(test_split)
-    assert len(train_split) == 7
-    assert len(test_split) == 3
+    assert_equal(len(train_split), 7)
+    assert_equal(len(test_split), 3)
 
 
 def test_train_split_larger_than_valid_and_test_splits(all_molecules):
     train_split, valid_split, test_split = scaffold_train_valid_test_split(
         all_molecules, train_size=0.7, valid_size=0.2, test_size=0.1
     )
-
     assert len(train_split) > len(valid_split)
     assert len(valid_split) > len(test_split)
-    assert len(train_split) == 7
-    assert len(valid_split) == 2
-    assert len(test_split) == 1
+    assert_equal(len(train_split), 7)
+    assert_equal(len(valid_split), 2)
+    assert_equal(len(test_split), 1)
 
 
 def test_scaffold_creation_total_count(all_molecules):
@@ -105,7 +106,7 @@ def test_scaffold_creation_total_count(all_molecules):
 def test_no_ring_molecules():
     smiles_list = ["CCO", "CCN", "CCC", "CCCl", "CCBr"]
     scaffolds = _create_scaffold_sets(smiles_list)
-    assert len(scaffolds) == 1
+    assert_equal(len(scaffolds), 1)
 
 
 def test_scaffold_count_for_benzodiazepines():
@@ -114,9 +115,8 @@ def test_scaffold_count_for_benzodiazepines():
         "C1CN=C(C2=CC=CC=C2F)N=C1",
         "C1CN=C(C2=CC=CC=C2Cl)N=C1",
     ]
-
     scaffolds = _create_scaffold_sets(smiles_list)
-    assert len(scaffolds) == 1
+    assert_equal(len(scaffolds), 1)
 
 
 def test_scaffold_count_for_xanthines():
@@ -127,19 +127,17 @@ def test_scaffold_count_for_xanthines():
         "Cn1c(=O)c2[nH]cnc2n(C)c1=O",
     ]
     scaffolds = _create_scaffold_sets(smiles_list)
-    assert len(scaffolds) == 1
+    assert_equal(len(scaffolds), 1)
 
 
 def test_csk_high_degree_atoms():
     smiles = ["O=[U]=O", "F[U](F)(F)(F)(F)F"]
-
     scaffold_train_test_split(smiles, use_csk=True)
 
 
 def test_scaffold_train_test_split_returns_molecules(all_molecules):
     mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
     train_set, test_set = scaffold_train_test_split(mols, return_indices=False)
-
     assert all(isinstance(train, Mol) for train in train_set)
     assert all(isinstance(test, Mol) for test in test_set)
 
@@ -147,7 +145,6 @@ def test_scaffold_train_test_split_returns_molecules(all_molecules):
 def test_scaffold_train_test_split_return_indices(all_molecules):
     mols = [Chem.MolFromSmiles(smiles) for smiles in all_molecules]
     train_idxs, test_idxs = scaffold_train_test_split(mols, return_indices=True)
-
     assert all(isinstance(idx, int) for idx in train_idxs)
     assert all(isinstance(idx, int) for idx in test_idxs)
 
@@ -157,7 +154,6 @@ def test_scaffold_train_valid_test_split_returns_molecules(all_molecules):
     train_set, valid_set, test_set = scaffold_train_valid_test_split(
         mols, return_indices=False
     )
-
     assert all(isinstance(train, Mol) for train in train_set)
     assert all(isinstance(valid, Mol) for valid in valid_set)
     assert all(isinstance(test, Mol) for test in test_set)
@@ -168,118 +164,80 @@ def test_scaffold_train_valid_test_split_return_indices(all_molecules):
     train_idxs, valid_idxs, test_idxs = scaffold_train_valid_test_split(
         mols, return_indices=True
     )
-
     assert all(isinstance(idx, int) for idx in train_idxs)
     assert all(isinstance(idx, int) for idx in valid_idxs)
     assert all(isinstance(idx, int) for idx in test_idxs)
 
 
 def test_empty_train_subset_raises_an_error_train_test():
-    smiles_list = [
-        "C1CCCC(C2CC2)CC1",
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match="the resulting train set will be empty",
-    ):
+    smiles_list = ["C1CCCC(C2CC2)CC1"]
+    with pytest.raises(ValueError, match="the resulting train set will be empty"):
         scaffold_train_test_split(data=smiles_list)
 
 
 def test_empty_train_subset_raises_an_error_train_valid_test():
-    smiles_list = [
-        "C1CCCC(C2CC2)CC1",
-        "c1n[nH]cc1C1CCCCCC1",
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match="one of the sets will be empty",
-    ):
+    smiles_list = ["C1CCCC(C2CC2)CC1", "c1n[nH]cc1C1CCCCCC1"]
+    with pytest.raises(ValueError, match="one of the sets will be empty"):
         scaffold_train_valid_test_split(data=smiles_list)
 
 
-def test_train_test_split_properly_splits_csk_with_ints(
-    smiles_ten_scaffolds,
-):
+def test_train_test_split_properly_splits_csk_with_ints(smiles_ten_scaffolds):
     train_set, test_set = scaffold_train_test_split(
         data=smiles_ten_scaffolds, train_size=7, test_size=3, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(test_set) == 3
+    assert_equal(len(train_set), 7)
+    assert_equal(len(test_set), 3)
 
 
-def test_train_test_split_properly_splits_csk_with_floats(
-    smiles_ten_scaffolds,
-):
+def test_train_test_split_properly_splits_csk_with_floats(smiles_ten_scaffolds):
     train_set, test_set = scaffold_train_test_split(
-        data=smiles_ten_scaffolds,
-        train_size=0.7,
-        test_size=0.3,
-        use_csk=True,
+        data=smiles_ten_scaffolds, train_size=0.7, test_size=0.3, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(test_set) == 3
+    assert_equal(len(train_set), 7)
+    assert_equal(len(test_set), 3)
 
 
-def test_train_valid_test_split_properly_splits_csk_with_ints(
-    smiles_ten_scaffolds,
-):
+def test_train_valid_test_split_properly_splits_csk_with_ints(smiles_ten_scaffolds):
     train_set, valid_set, test_set = scaffold_train_valid_test_split(
-        data=smiles_ten_scaffolds,
-        train_size=7,
-        valid_size=2,
-        test_size=1,
-        use_csk=True,
+        data=smiles_ten_scaffolds, train_size=7, valid_size=2, test_size=1, use_csk=True
     )
-    assert len(train_set) == 7
-    assert len(valid_set) == 2
-    assert len(test_set) == 1
+    assert_equal(len(train_set), 7)
+    assert_equal(len(valid_set), 2)
+    assert_equal(len(test_set), 1)
 
 
-def test_train_valid_test_split_properly_splits_csk_with_floats(
-    smiles_ten_scaffolds,
-):
-    train_set, valid_size, test_set = scaffold_train_valid_test_split(
+def test_train_valid_test_split_properly_splits_csk_with_floats(smiles_ten_scaffolds):
+    train_set, valid_set, test_set = scaffold_train_valid_test_split(
         data=smiles_ten_scaffolds,
         train_size=0.7,
         valid_size=0.2,
         test_size=0.1,
         use_csk=True,
     )
-    assert len(train_set) == 7
-    assert len(valid_size) == 2
-    assert len(test_set) == 1
+    assert_equal(len(train_set), 7)
+    assert_equal(len(valid_set), 2)
+    assert_equal(len(test_set), 1)
 
 
 def test_train_test_split_with_additional_data(smiles_ten_scaffolds):
     train_set, test_set, train_data, test_data = scaffold_train_test_split(
-        smiles_ten_scaffolds,
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        smiles_ten_scaffolds, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     )
-    assert len(train_set) == 8
-    assert len(test_set) == 2
-
-    assert len(train_data) == 8
-    assert len(test_data) == 2
+    assert_equal(len(train_set), 8)
+    assert_equal(len(test_set), 2)
+    assert_equal(len(train_data), 8)
+    assert_equal(len(test_data), 2)
 
 
 def test_train_valid_test_split_with_additional_data(smiles_ten_scaffolds):
-    (
-        train_set,
-        valid_set,
-        test_set,
-        train_data,
-        valid_data,
-        test_data,
-    ) = scaffold_train_valid_test_split(
-        smiles_ten_scaffolds,
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    train_set, valid_set, test_set, train_data, valid_data, test_data = (
+        scaffold_train_valid_test_split(
+            smiles_ten_scaffolds, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
     )
-    assert len(train_set) == 8
-    assert len(valid_set) == 1
-    assert len(test_set) == 1
-
-    assert len(train_data) == 8
-    assert len(valid_data) == 1
-    assert len(test_data) == 1
+    assert_equal(len(train_set), 8)
+    assert_equal(len(valid_set), 1)
+    assert_equal(len(test_set), 1)
+    assert_equal(len(train_data), 8)
+    assert_equal(len(valid_data), 1)
+    assert_equal(len(test_data), 1)

--- a/tests/preprocessing/conformer_generator.py
+++ b/tests/preprocessing/conformer_generator.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal, assert_equal
 from rdkit.Chem import AddHs, MolFromSmiles
 
 from skfp.preprocessing import ConformerGenerator, MolFromSmilesTransformer
@@ -9,7 +10,7 @@ def test_conformer_generator(smallest_mols_list):
     conf_gen = ConformerGenerator(n_jobs=-1)
     mols_with_confs = conf_gen.transform(smallest_mols_list)
 
-    assert len(mols_with_confs) == len(smallest_mols_list)
+    assert_equal(len(mols_with_confs), len(smallest_mols_list))
     assert all(mol.HasProp("conf_id") for mol in mols_with_confs)
 
 
@@ -32,8 +33,8 @@ def test_conformer_generator_with_hydrogens(smallest_mols_list):
     smallest_mols_with_hs = [AddHs(mol) for mol in smallest_mols_list]
     mols_with_confs_2 = conf_gen.transform(smallest_mols_with_hs)
 
-    assert len(mols_with_confs) == len(smallest_mols_list)
-    assert len(mols_with_confs_2) == len(smallest_mols_list)
+    assert_equal(len(mols_with_confs), len(smallest_mols_list))
+    assert_equal(len(mols_with_confs_2), len(smallest_mols_list))
     assert all(mol.HasProp("conf_id") for mol in mols_with_confs_2)
     assert all(
         mol.GetIntProp("conf_id") == mol_2.GetIntProp("conf_id")
@@ -45,7 +46,7 @@ def test_conformer_generator_force_field_optimization(smallest_mols_list):
     conf_gen = ConformerGenerator(optimize_force_field="UFF", n_jobs=-1)
     mols_with_confs = conf_gen.transform(smallest_mols_list)
 
-    assert len(mols_with_confs) == len(smallest_mols_list)
+    assert_equal(len(mols_with_confs), len(smallest_mols_list))
     assert all(mol.HasProp("conf_id") for mol in mols_with_confs)
 
 
@@ -58,7 +59,7 @@ def test_conformer_generator_multiple_conformers(smallest_mols_list):
     )
     mols_with_confs = conf_gen.transform(smallest_mols_list)
 
-    assert len(mols_with_confs) == len(smallest_mols_list)
+    assert_equal(len(mols_with_confs), len(smallest_mols_list))
     assert all(mol.HasProp("conf_id") for mol in mols_with_confs)
 
 
@@ -77,15 +78,15 @@ def test_conformer_generator_error_handling(smallest_mols_list):
     conf_gen = ConformerGenerator(max_gen_attempts=100, errors="filter", n_jobs=-1)
     mols_conf, y_conf = conf_gen.transform_x_y(mols, y)
     assert all(mol.HasProp("conf_id") for mol in mols_conf)
-    assert len(mols_conf) == len(y_conf)
-    assert len(mols_conf) == len(mols) - 1
+    assert_equal(len(mols_conf), len(y_conf))
+    assert_equal(len(mols_conf), len(mols) - 1)
 
     conf_gen = ConformerGenerator(max_gen_attempts=100, errors="ignore", n_jobs=-1)
     mols_conf, y_conf = conf_gen.transform_x_y(mols, y)
     assert all(mol.HasProp("conf_id") for mol in mols_conf)
-    assert mols_conf[-1].GetIntProp("conf_id") == -1
-    assert len(mols_conf) == len(y_conf)
-    assert len(mols_conf) == len(mols)
+    assert_equal(mols_conf[-1].GetIntProp("conf_id"), -1)
+    assert_equal(len(mols_conf), len(y_conf))
+    assert_equal(len(mols_conf), len(mols))
 
 
 def test_conformer_generator_copy_y():
@@ -94,5 +95,5 @@ def test_conformer_generator_copy_y():
     conf_gen = ConformerGenerator()
     mols_out, labels_out = conf_gen.transform_x_y(mols, labels, copy=True)
 
-    assert np.array_equal(labels_out, labels)
+    assert_array_equal(labels_out, labels)
     assert labels_out is not labels

--- a/tests/preprocessing/input_output/aminoseq.py
+++ b/tests/preprocessing/input_output/aminoseq.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol, MolFromFASTA, MolToSmiles
 
 from skfp.preprocessing import MolFromAminoseqTransformer
@@ -24,7 +25,7 @@ def test_mol_from_fasta(fasta_list):
     mol_from_fasta = MolFromAminoseqTransformer()
     mols_list = mol_from_fasta.transform(fasta_list)
 
-    assert len(mols_list) == len(fasta_list)
+    assert_equal(len(mols_list), len(fasta_list))
     assert all(isinstance(x, Mol) for x in mols_list)
 
 
@@ -34,7 +35,7 @@ def test_mol_to_and_from_fasta(fasta_list, peptides_smiles_list):
     peptide_list = mol_from_fasta.transform(fasta_list)
     smiles_list = [MolToSmiles(mol) for mol in peptide_list]
 
-    assert smiles_list == peptides_smiles_list
+    assert_equal(smiles_list, peptides_smiles_list)
 
 
 def test_mol_from_fasta_and_sequence(fasta_list, sequence_list):
@@ -47,7 +48,7 @@ def test_mol_from_fasta_and_sequence(fasta_list, sequence_list):
     smiles_list_fasta = [MolToSmiles(mol) for mol in mols_list_fasta]
     smiles_list_sequence = [MolToSmiles(mol) for mol in mols_list_sequence]
 
-    assert smiles_list_fasta == smiles_list_sequence
+    assert_equal(smiles_list_fasta, smiles_list_sequence)
 
 
 def test_parallel_to_and_from_fasta(peptide_list, fasta_list):
@@ -59,7 +60,7 @@ def test_parallel_to_and_from_fasta(peptide_list, fasta_list):
     mols_list_parallel = mol_from_fasta_parallel.transform(fasta_list)
     smiles_list_parallel = [MolToSmiles(mol) for mol in mols_list_parallel]
 
-    assert smiles_list_seq == smiles_list_parallel
+    assert_equal(smiles_list_seq, smiles_list_parallel)
 
 
 def test_from_invalid_fasta(fasta_list):
@@ -70,15 +71,14 @@ def test_from_invalid_fasta(fasta_list):
     mol_from_aminoseq = MolFromAminoseqTransformer(valid_only=True)
     mols_list_2 = mol_from_aminoseq.transform(fasta_list + invalid_fasta_list)
 
-    assert len(mols_list) == len(fasta_list) + len(invalid_fasta_list)
-    assert len(mols_list_2) == len(fasta_list)
+    assert_equal(len(mols_list), len(fasta_list) + len(invalid_fasta_list))
+    assert_equal(len(mols_list_2), len(fasta_list))
 
 
 def test_from_invalid_smiles_with_y(fasta_list):
     invalid_fasta_list = ["[H]=[H]", "..."]
     all_fasta_list = fasta_list + invalid_fasta_list
     labels = np.ones(len(all_fasta_list))
-
     labels[-len(invalid_fasta_list) :] = 0
 
     mol_from_aminoseq = MolFromAminoseqTransformer(valid_only=False)
@@ -87,9 +87,9 @@ def test_from_invalid_smiles_with_y(fasta_list):
     mol_from_aminoseq = MolFromAminoseqTransformer(valid_only=True)
     mols_list_2, y_2 = mol_from_aminoseq.transform_x_y(all_fasta_list, labels)
 
-    assert len(mols_list) == len(all_fasta_list)
-    assert len(mols_list_2) == len(fasta_list)
+    assert_equal(len(mols_list), len(all_fasta_list))
+    assert_equal(len(mols_list_2), len(fasta_list))
 
-    assert len(y) == len(all_fasta_list)
-    assert len(y_2) == len(fasta_list)
-    assert len(mols_list_2) == len(y_2)
+    assert_equal(len(y), len(all_fasta_list))
+    assert_equal(len(y_2), len(fasta_list))
+    assert_equal(len(mols_list_2), len(y_2))

--- a/tests/preprocessing/input_output/inchi.py
+++ b/tests/preprocessing/input_output/inchi.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol, MolFromSmiles, MolToInchi
 
 from skfp.preprocessing import MolFromInchiTransformer, MolToInchiTransformer
@@ -14,7 +15,7 @@ def test_mol_from_inchi(inchi_list):
     mol_from_inchi = MolFromInchiTransformer()
     mols_list = mol_from_inchi.transform(inchi_list)
 
-    assert len(mols_list) == len(inchi_list)
+    assert_equal(len(mols_list), len(inchi_list))
     assert all(isinstance(x, Mol) for x in mols_list)
 
 
@@ -22,7 +23,7 @@ def test_mol_to_inchi(mols_list):
     mol_to_inchi = MolToInchiTransformer()
     inchi_list = mol_to_inchi.transform(mols_list)
 
-    assert len(inchi_list) == len(mols_list)
+    assert_equal(len(inchi_list), len(mols_list))
     assert all(isinstance(x, str) for x in inchi_list)
 
 
@@ -33,7 +34,7 @@ def test_mol_to_and_from_inchi(inchi_list):
     mols_list = mol_from_inchi.transform(inchi_list)
     inchi_list_2 = mol_to_inchi.transform(mols_list)
 
-    assert inchi_list_2 == inchi_list
+    assert_equal(inchi_list_2, inchi_list)
 
 
 def test_parallel_to_and_from_inchi(inchi_list):
@@ -49,8 +50,8 @@ def test_parallel_to_and_from_inchi(inchi_list):
     inchi_list_2_seq = mol_to_inchi_seq.transform(mols_list_seq)
     inchi_list_2_parallel = mol_to_inchi_parallel.transform(mols_list_parallel)
 
-    assert inchi_list_2_seq == inchi_list
-    assert inchi_list_2_seq == inchi_list_2_parallel
+    assert_equal(inchi_list_2_seq, inchi_list)
+    assert_equal(inchi_list_2_seq, inchi_list_2_parallel)
 
 
 def test_from_invalid_inchi(inchi_list):
@@ -61,8 +62,8 @@ def test_from_invalid_inchi(inchi_list):
     mol_from_inchi = MolFromInchiTransformer(valid_only=True)
     mols_list_2 = mol_from_inchi.transform(inchi_list + invalid_inchi_list)
 
-    assert len(mols_list) == len(inchi_list) + len(invalid_inchi_list)
-    assert len(mols_list_2) == len(inchi_list)
+    assert_equal(len(mols_list), len(inchi_list) + len(invalid_inchi_list))
+    assert_equal(len(mols_list_2), len(inchi_list))
 
 
 def test_inchi_transform_x_y(inchi_list):
@@ -71,5 +72,5 @@ def test_inchi_transform_x_y(inchi_list):
     mol_from_inchi = MolFromInchiTransformer(valid_only=True)
     mols, labels = mol_from_inchi.transform_x_y(inchi_list, labels)
 
-    assert len(mols) == len(inchi_list)
-    assert len(labels) == len(inchi_list)
+    assert_equal(len(mols), len(inchi_list))
+    assert_equal(len(labels), len(inchi_list))

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.preprocessing import MolFromSDFTransformer, MolToSDFTransformer
@@ -22,7 +23,7 @@ def test_mol_from_sdf(sdf_in_file_path):
     mol_from_sdf = MolFromSDFTransformer()
     mols = mol_from_sdf.transform(sdf_in_file_path)
 
-    assert len(mols) == 1
+    assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)
 
 
@@ -40,7 +41,7 @@ def test_mol_to_and_from_sdf(mols_list, sdf_out_file_path):
     mol_to_sdf.transform(mols_list)
     mols_list_2 = mol_from_sdf.transform(sdf_out_file_path)
 
-    assert len(mols_list_2) == len(mols_list)
+    assert_equal(len(mols_list_2), len(mols_list))
     assert all(isinstance(x, Mol) for x in mols_list_2)
 
 

--- a/tests/preprocessing/input_output/smiles.py
+++ b/tests/preprocessing/input_output/smiles.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.preprocessing import MolFromSmilesTransformer, MolToSmilesTransformer
@@ -8,7 +9,7 @@ def test_mol_from_smiles(smiles_list):
     mol_from_smiles = MolFromSmilesTransformer()
     mols_list = mol_from_smiles.transform(smiles_list)
 
-    assert len(mols_list) == len(smiles_list)
+    assert_equal(len(mols_list), len(smiles_list))
     assert all(isinstance(x, Mol) for x in mols_list)
 
 
@@ -16,7 +17,7 @@ def test_mol_to_smiles(mols_list):
     mol_to_smiles = MolToSmilesTransformer()
     smiles_list = mol_to_smiles.transform(mols_list)
 
-    assert len(smiles_list) == len(mols_list)
+    assert_equal(len(smiles_list), len(mols_list))
     assert all(isinstance(x, str) for x in smiles_list)
 
 
@@ -50,8 +51,8 @@ def test_from_invalid_smiles(smiles_list):
     mol_from_smiles = MolFromSmilesTransformer(valid_only=True)
     mols_list_2 = mol_from_smiles.transform(smiles_list + invalid_smiles_list)
 
-    assert len(mols_list) == len(smiles_list) + len(invalid_smiles_list)
-    assert len(mols_list_2) == len(smiles_list)
+    assert_equal(len(mols_list), len(smiles_list) + len(invalid_smiles_list))
+    assert_equal(len(mols_list_2), len(smiles_list))
 
 
 def test_from_invalid_smiles_with_y(smiles_list):
@@ -67,9 +68,9 @@ def test_from_invalid_smiles_with_y(smiles_list):
     mol_from_smiles = MolFromSmilesTransformer(valid_only=True)
     mols_list_2, y_2 = mol_from_smiles.transform_x_y(all_smiles_list, labels)
 
-    assert len(mols_list) == len(all_smiles_list)
-    assert len(mols_list_2) == len(smiles_list)
+    assert_equal(len(mols_list), len(all_smiles_list))
+    assert_equal(len(mols_list_2), len(smiles_list))
 
-    assert len(y) == len(all_smiles_list)
-    assert len(y_2) == len(smiles_list)
-    assert len(mols_list_2) == len(y_2)
+    assert_equal(len(y), len(all_smiles_list))
+    assert_equal(len(y_2), len(smiles_list))
+    assert_equal(len(mols_list_2), len(y_2))

--- a/tests/preprocessing/standardization.py
+++ b/tests/preprocessing/standardization.py
@@ -1,3 +1,4 @@
+from numpy.testing import assert_array_equal, assert_equal
 from rdkit.Chem import GetMolFrags, MolToSmiles
 
 from skfp.preprocessing import MolStandardizer
@@ -10,7 +11,7 @@ def test_mol_standardizer(smiles_list):
     mols = standardizer.transform(smiles_list)
     mols_parallel = standardizer_parallel.transform(smiles_list)
 
-    assert len(mols) == len(mols_parallel)
+    assert_equal(len(mols), len(mols_parallel))
     for mol, mol_2 in zip(mols, mols_parallel, strict=False):
         assert MolToSmiles(mol) == MolToSmiles(mol_2)
 
@@ -26,7 +27,7 @@ def test_multifragment_standardization():
     mols = standardizer.transform(multi_fragment_smiles)
     num_frags = [len(GetMolFrags(mol)) for mol in mols]
     num_frags_expected = [2, 2, 2, 5]
-    assert num_frags == num_frags_expected
+    assert_array_equal(num_frags, num_frags_expected)
 
 
 def test_largest_fragment_standardization(smiles_list):

--- a/tests/sklearn_compatibility/basic_checks.py
+++ b/tests/sklearn_compatibility/basic_checks.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 from sklearn import clone
 from sklearn.utils._testing import create_memmap_backed_data, set_random_state
 from sklearn.utils.estimator_checks import (
@@ -22,14 +23,11 @@ from skfp.bases import BaseFilter
 from skfp.bases.base_fp_transformer import BaseFingerprintTransformer
 
 """
-Note that many check functions here needed to be copied from Scikit-learn and
-slightly modified for compatibility with our input X being a list of SMILES or
-RDKit molecules.
+Note: several check functions are adapted from Scikit-learn
+to work with our inputs (SMILES strings or RDKit molecules).
 """
 
-
-# unfortunately, there is no way to pass data to Scikit-learn tests other than
-# global variables
+# global test data
 n_samples = 10
 X = []
 y = None
@@ -57,9 +55,8 @@ def test_basic_sklearn_checks_for_fingerprints(fp_name, fp_cls, mols_conformers_
     X = mols_conformers_list[:n_samples]
     y = np.arange(n_samples) % 2
 
-    # USR and USRCAT don't work for molecules with 3 or fewer atoms, so we use NaNs there
+    # USR and USRCAT fail for molecules with ≤3 atoms → allow NaN fallback
     fp_obj = fp_cls(errors="NaN") if "USR" in fp_name else fp_cls()
-
     run_checks(fp_name, fp_obj)
 
 
@@ -70,17 +67,16 @@ def test_basic_sklearn_checks_for_preprocessors(
     global X, y
     y = np.arange(n_samples) % 2
 
-    # skip SDF transformers - they have slightly different API
+    # skip SDF transformers (different API)
     if preproc_name in {"MolFromSDFTransformer", "MolToSDFTransformer"}:
         return
 
     if preproc_name in {"MolFromSmilesTransformer", "MolFromInchiTransformer"}:
         X = smallest_smiles_list[:n_samples]
+    elif preproc_name == "MolFromAminoseqTransformer":
+        X = fasta_list
     else:
         X = smallest_mols_list[:n_samples]
-
-    if preproc_name == "MolFromAminoseqTransformer":
-        X = fasta_list
 
     preproc_obj = preproc_cls()
     run_checks(preproc_name, preproc_obj)
@@ -109,15 +105,11 @@ def run_checks(fp_name: str, fp_obj: BaseFingerprintTransformer):
 
 
 def check_fit_score_takes_y(name: str, estimator_orig: BaseFingerprintTransformer):
-    """
-    Check that all estimators accept an optional y in fit and score,
-    so they can be used in pipelines.
-    """
+    """Check that all estimators accept optional y in fit/score, for pipeline compatibility."""
     estimator = clone(estimator_orig)
     set_random_state(estimator)
 
-    funcs = ["fit", "fit_transform"]
-    for func_name in funcs:
+    for func_name in ["fit", "fit_transform"]:
         func = getattr(estimator, func_name, None)
         if func is None:
             continue
@@ -125,14 +117,11 @@ def check_fit_score_takes_y(name: str, estimator_orig: BaseFingerprintTransforme
         func(X, y)
         args = [p.name for p in inspect.signature(func).parameters.values()]
         if args[0] == "self":
-            # available_if makes methods into functions
-            # with an explicit "self", so need to shift arguments
             args = args[1:]
         if args[1] not in ["y", "Y"]:
-            est_name = type(estimator).__name__
             raise AssertionError(
-                f"Expected y or Y as second argument for method"
-                f"{func_name} of {est_name}, got arguments: {args}"
+                f"Expected y or Y as 2nd argument for {func_name} of {type(estimator).__name__}, "
+                f"got {args}"
             )
 
 
@@ -141,55 +130,46 @@ def check_estimators_pickle(
     estimator_orig: BaseFingerprintTransformer,
     readonly_memmap: bool = False,
 ):
-    """
-    Test that we can pickle all estimators.
-    """
+    """Check that all estimators can be pickled and give consistent results."""
     check_methods = ["predict", "transform", "decision_function", "predict_proba"]
 
-    # nondeterministic, classes, those that cannot be compares with NumPy etc.
-    omit_results_check = ["GETAWAYFingerprint", "ConformerGenerator"]
+    # some outputs are non-deterministic or not comparable
+    omit_results_check = {"GETAWAYFingerprint", "ConformerGenerator"}
 
     estimator = clone(estimator_orig)
-
     set_random_state(estimator)
     estimator.fit(X, y)
 
     if readonly_memmap:
         unpickled_estimator = create_memmap_backed_data(estimator)
     else:
-        # No need to touch the file system in that case.
         pickled_estimator = pickle.dumps(estimator)
         unpickled_estimator = pickle.loads(pickled_estimator)
 
-    result = dict()
+    results = {}
     for method in check_methods:
         if hasattr(estimator, method):
-            result[method] = getattr(estimator, method)(X)
+            results[method] = getattr(estimator, method)(X)
 
-    for method in result:  # noqa: PLC0206
+    for method, result in results.items():
         unpickled_result = getattr(unpickled_estimator, method)(X)
 
-        if isinstance(result[method], list):
-            assert len(result[method]) == len(unpickled_result)
+        if isinstance(result, list):
+            assert_equal(len(result), len(unpickled_result))
         else:
-            assert result[method].shape == unpickled_result.shape
+            assert_equal(result.shape, unpickled_result.shape)
             if name not in omit_results_check:
-                np.testing.assert_allclose(
-                    result[method], unpickled_result, atol=1e-1, equal_nan=True
-                )
+                assert_allclose(result, unpickled_result, atol=1e-1, equal_nan=True)
 
 
 def check_transformers_unfitted_stateless(
     name: str, transformer: BaseFingerprintTransformer
 ):
-    """
-    Check that using transform without prior fitting
-    doesn't raise a NotFittedError for stateless transformers.
-    """
+    """Check that transform() without fit() works for stateless transformers."""
     transformer = clone(transformer)
     X_trans = transformer.transform(X)
 
     if issubclass(transformer.__class__, BaseFilter):
         assert len(X_trans) <= len(X)
     else:
-        assert len(X) == len(X_trans)
+        assert_equal(len(X), len(X_trans))

--- a/tests/sklearn_compatibility/basic_checks.py
+++ b/tests/sklearn_compatibility/basic_checks.py
@@ -174,7 +174,7 @@ def check_estimators_pickle(
         else:
             assert result[method].shape == unpickled_result.shape
             if name not in omit_results_check:
-                assert np.allclose(
+                np.testing.assert_allclose(
                     result[method], unpickled_result, atol=1e-1, equal_nan=True
                 )
 

--- a/tests/utils/functions.py
+++ b/tests/utils/functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from numpy.testing import assert_equal
 
 from skfp.utils import get_data_from_indices
 
@@ -8,18 +9,18 @@ def test_get_data_from_indices_numpy():
     data = np.array([1, 2, 3, 4])
     idxs = [0, 2]
     selected_data = get_data_from_indices(data, idxs)
-    assert selected_data == [1, 3]
+    assert_equal(selected_data, [1, 3])
 
 
 def test_get_data_from_indices_pandas():
     data = pd.Series([1, 2, 3, 4])
     idxs = [0, 2]
     selected_data = get_data_from_indices(data, idxs)
-    assert selected_data == [1, 3]
+    assert_equal(selected_data, [1, 3])
 
 
 def test_get_data_from_indices_pandas_str_index():
     data = pd.Series([1, 2, 3, 4], index=["a", "b", "c", "d"])
     idxs = [0, 2]
     selected_data = get_data_from_indices(data, idxs)
-    assert selected_data == [1, 3]
+    assert_equal(selected_data, [1, 3])

--- a/tests/utils/parallel.py
+++ b/tests/utils/parallel.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+from numpy.testing import assert_equal
 from sklearn.utils.parallel import delayed
 
 from skfp.utils.parallel import ProgressParallel, run_in_parallel
@@ -33,7 +34,7 @@ def test_run_in_parallel():
     data = list(range(100))
     result_sequential = func(data)
     result_parallel = run_in_parallel(func, data, n_jobs=-1, flatten_results=True)
-    assert result_sequential == result_parallel
+    assert_equal(result_sequential, result_parallel)
 
 
 def test_run_in_parallel_batch_size():
@@ -43,7 +44,7 @@ def test_run_in_parallel_batch_size():
     result_parallel = run_in_parallel(
         func, data, n_jobs=-1, batch_size=1, flatten_results=True
     )
-    assert result_sequential == result_parallel
+    assert_equal(result_sequential, result_parallel)
 
 
 def test_run_in_parallel_invalid_batch_size():
@@ -60,7 +61,7 @@ def test_run_in_parallel_single_element_func():
     data = list(range(100))
     result_parallel = run_in_parallel(func, data, n_jobs=-1, single_element_func=True)
     expected_result = list(range(1, 101))
-    assert result_parallel == expected_result
+    assert_equal(result_parallel, expected_result)
 
 
 def test_run_in_parallel_verbose_dict(capsys):


### PR DESCRIPTION
## Changes

Refactoring of tests to use `np.testing.array_equal` primarily to compare values. It very nicely prints the actual and expected values, in comparison to raw `assert`.

Previous:
```
>       assert np.array_equal(X_skfp + 1, X_rdkit)
E       AssertionError

tests/fingerprints/atom_pair.py:20: AssertionError
```

Current:
```
>       assert_equal(X_skfp + 1, X_rdkit)
E       AssertionError: 
E       Arrays are not equal
E       
E       Mismatched elements: 204800 / 204800 (100%)
E       Max absolute difference among violations: 1
E       Max relative difference among violations: 1.
E        ACTUAL: array([[1, 1, 1, ..., 1, 1, 1],
E              [2, 2, 2, ..., 1, 1, 1],
E              [1, 1, 1, ..., 1, 1, 1],...
E        DESIRED: array([[0, 0, 0, ..., 0, 0, 0],
E              [1, 1, 1, ..., 0, 0, 0],
E              [0, 0, 0, ..., 0, 0, 0],...
```

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
