### PR TITLE
Add examples to train-test split functions in various splitters

### DIFF
--- a/skfp/model_selection/splitters/butina_split.py
+++ b/skfp/model_selection/splitters/butina_split.py
@@ -157,8 +157,8 @@ def butina_train_test_split(
     >>> from skfp.model_selection.splitters import butina_train_test_split
     >>> smiles = ['CCO', 'CCN', 'CCC', 'CCCl', 'CCBr', 'CCI', 'CCF', 'CC=O']
     >>> train_smiles, test_smiles = butina_train_test_split(smiles, train_size=0.75, test_size=0.25)
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCBr', 'CCI', 'CCF', 'CC=O', 'CCO', 'CCC']
+    >>> train_smiles
+    ['CCBr', 'CCI', 'CCF', 'CC=O', 'CCO', 'CCC']
     """
     train_size, test_size = validate_train_test_split_sizes(
         train_size, test_size, len(data)
@@ -352,8 +352,8 @@ def butina_train_valid_test_split(
     >>> train_smiles, valid_smiles, test_smiles = butina_train_valid_test_split(
     ...     smiles, train_size=0.5, valid_size=0.25, test_size=0.25
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCF', 'CC=O', 'CCO', 'CCC']
+    >>> train_smiles
+    ['CCF', 'CC=O', 'CCO', 'CCC']
     """
     train_size, valid_size, test_size = validate_train_valid_test_split_sizes(
         train_size, valid_size, test_size, len(data)

--- a/skfp/model_selection/splitters/maxmin_split.py
+++ b/skfp/model_selection/splitters/maxmin_split.py
@@ -121,8 +121,8 @@ def maxmin_train_test_split(
     >>> train_smiles, test_smiles = maxmin_train_test_split(
     ...     smiles, train_size=0.75, test_size=0.25, random_state=42
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
+    >>> train_smiles
+    ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
     """
     data_size = len(data)
     train_size, test_size = validate_train_test_split_sizes(
@@ -279,8 +279,8 @@ def maxmin_train_valid_test_split(
     >>> train_smiles, valid_smiles, test_smiles = maxmin_train_valid_test_split(
     ...     smiles, train_size=0.5, valid_size=0.25, test_size=0.25, random_state=42
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCCl', 'CCBr', 'CCI', 'CCF']
+    >>> train_smiles
+    ['CCCl', 'CCBr', 'CCI', 'CCF']
     """
     data_size = len(data)
     train_size, valid_size, test_size = validate_train_valid_test_split_sizes(

--- a/skfp/model_selection/splitters/pubchem_split.py
+++ b/skfp/model_selection/splitters/pubchem_split.py
@@ -138,8 +138,8 @@ def pubchem_train_test_split(
     >>> train_smiles, test_smiles = pubchem_train_test_split(
     ...     smiles, train_size=0.75, test_size=0.25, n_jobs=1, n_retries=1
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCCl', 'CCI', 'CCO', 'CCN', 'CCBr', 'CCC']
+    >>> train_smiles
+    ['CCCl', 'CCI', 'CCO', 'CCN', 'CCBr', 'CCC']
     """
     years = _get_pubchem_years(data, n_jobs, n_retries, verbose)
 
@@ -314,8 +314,8 @@ def pubchem_train_valid_test_split(
     >>> train_smiles, valid_smiles, test_smiles = pubchem_train_valid_test_split(
     ...     smiles, train_size=0.5, valid_size=0.25, test_size=0.25, n_jobs=1, n_retries=1, verbose=0
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCCl', 'CCI', 'CCO', 'CCN']
+    >>> train_smiles
+    ['CCCl', 'CCI', 'CCO', 'CCN']
     """
     years = _get_pubchem_years(data, n_jobs, n_retries, verbose)
 

--- a/skfp/model_selection/splitters/randomized_scaffold_split.py
+++ b/skfp/model_selection/splitters/randomized_scaffold_split.py
@@ -133,8 +133,8 @@ def randomized_scaffold_train_test_split(
     >>> train_smiles, test_smiles = randomized_scaffold_train_test_split(
     ...     smiles, train_size=6, test_size=2, random_state=42
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['C1CCCCC1', 'c1ccccc1']
+    >>> train_smiles
+    ['C1CCCCC1', 'c1ccccc1']
     """
     train_size, test_size = validate_train_test_split_sizes(
         train_size, test_size, len(data)
@@ -307,8 +307,8 @@ def randomized_scaffold_train_valid_test_split(
     >>> train_smiles, valid_smiles, test_smiles = randomized_scaffold_train_valid_test_split(
     ...     smiles, train_size=6, valid_size=1, test_size=1, random_state=42
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['c1ccccc1']
+    >>> train_smiles
+    ['c1ccccc1']
     """
     train_size, valid_size, test_size = validate_train_valid_test_split_sizes(
         train_size, valid_size, test_size, len(data)

--- a/skfp/model_selection/splitters/scaffold_split.py
+++ b/skfp/model_selection/splitters/scaffold_split.py
@@ -123,8 +123,8 @@ def scaffold_train_test_split(
     >>> from skfp.model_selection.splitters import scaffold_train_test_split
     >>> smiles = ['c1ccccc1', 'C1CCCCC1', 'CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
     >>> train_smiles, test_smiles = scaffold_train_test_split(smiles, train_size=6, test_size=2)
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
+    >>> train_smiles
+    ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
     """
     train_size, test_size = validate_train_test_split_sizes(
         train_size, test_size, len(data)
@@ -288,8 +288,8 @@ def scaffold_train_valid_test_split(
     >>> train_smiles, valid_smiles, test_smiles = scaffold_train_valid_test_split(
     ...     smiles, train_size=6, valid_size=1, test_size=1
     ... )
-    >>> print('Train SMILES:', train_smiles)
-    Train SMILES: ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
+    >>> train_smiles
+    ['CCO', 'CCN', 'CCCl', 'CCBr', 'CCI', 'CCF']
     """
     train_size, valid_size, test_size = validate_train_valid_test_split_sizes(
         train_size, valid_size, test_size, len(data)


### PR DESCRIPTION
## Changes

Added examples to splitting functions docs.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
