### PR TITLE
Add explicit doc convention to ruff.toml

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -111,5 +111,8 @@ ignore = [
 # extremely long lines
 max-line-length = 200
 
+[lint.pydocstyle]
+convention = "numpy"
+
 [lint.mccabe]
 max-complexity = 10 # B in xenon rating


### PR DESCRIPTION
## Changes

Added additional checks for doc convention

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
