### PR TITLE
Fix datasets typing

### DIFF
--- a/skfp/datasets/lrgb/benchmark.py
+++ b/skfp/datasets/lrgb/benchmark.py
@@ -126,7 +126,7 @@ def load_lrgb_mol_dataset(
     standardize_labels: bool = True,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load LRGB molecular dataset by name.
 

--- a/skfp/datasets/lrgb/peptides_func.py
+++ b/skfp/datasets/lrgb/peptides_func.py
@@ -21,7 +21,7 @@ def load_peptides_func(
     mol_type: str = "SMILES",
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Peptides-func dataset.
 

--- a/skfp/datasets/lrgb/peptides_struct.py
+++ b/skfp/datasets/lrgb/peptides_struct.py
@@ -24,7 +24,7 @@ def load_peptides_struct(
     standardize_labels: bool = True,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Peptides-struct dataset.
 

--- a/skfp/datasets/moleculeace/benchmark.py
+++ b/skfp/datasets/moleculeace/benchmark.py
@@ -235,7 +235,7 @@ def load_moleculeace_dataset(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load MoleculeACE dataset by name.
 

--- a/skfp/datasets/moleculeace/moleculeace.py
+++ b/skfp/datasets/moleculeace/moleculeace.py
@@ -19,7 +19,7 @@ def load_chembl204_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL204 Ki dataset.
 
@@ -105,7 +105,7 @@ def load_chembl214_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL214 Ki dataset.
 
@@ -191,7 +191,7 @@ def load_chembl218_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL218 EC50 dataset.
 
@@ -277,7 +277,7 @@ def load_chembl219_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL219 Ki dataset.
 
@@ -363,7 +363,7 @@ def load_chembl228_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL228 Ki dataset.
 
@@ -449,7 +449,7 @@ def load_chembl231_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL231 Ki dataset.
 
@@ -535,7 +535,7 @@ def load_chembl233_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL233 Ki dataset.
 
@@ -621,7 +621,7 @@ def load_chembl234_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL234 Ki dataset.
 
@@ -707,7 +707,7 @@ def load_chembl235_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL235 EC50 dataset.
 
@@ -793,7 +793,7 @@ def load_chembl236_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL236 Ki dataset.
 
@@ -879,7 +879,7 @@ def load_chembl237_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL237 EC50 dataset.
 
@@ -965,7 +965,7 @@ def load_chembl237_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL237 Ki dataset.
 
@@ -1051,7 +1051,7 @@ def load_chembl238_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL238 Ki dataset.
 
@@ -1137,7 +1137,7 @@ def load_chembl239_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL239 EC50 dataset.
 
@@ -1223,7 +1223,7 @@ def load_chembl244_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL244 Ki dataset.
 
@@ -1309,7 +1309,7 @@ def load_chembl262_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL262 Ki dataset.
 
@@ -1395,7 +1395,7 @@ def load_chembl264_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL264 Ki dataset.
 
@@ -1481,7 +1481,7 @@ def load_chembl287_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL287 Ki dataset.
 
@@ -1567,7 +1567,7 @@ def load_chembl1862_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL1862 Ki dataset.
 
@@ -1653,7 +1653,7 @@ def load_chembl1871_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL1871 Ki dataset.
 
@@ -1739,7 +1739,7 @@ def load_chembl2034_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL2034 Ki dataset.
 
@@ -1825,7 +1825,7 @@ def load_chembl2047_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL2047 EC50 dataset.
 
@@ -1911,7 +1911,7 @@ def load_chembl2147_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL2147 Ki dataset.
 
@@ -1997,7 +1997,7 @@ def load_chembl2835_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL2835 Ki dataset.
 
@@ -2083,7 +2083,7 @@ def load_chembl2971_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL2971 Ki dataset.
 
@@ -2169,7 +2169,7 @@ def load_chembl3979_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL3979 EC50 dataset.
 
@@ -2255,7 +2255,7 @@ def load_chembl4005_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL4005 Ki dataset.
 
@@ -2341,7 +2341,7 @@ def load_chembl4203_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL4203 Ki dataset.
 
@@ -2427,7 +2427,7 @@ def load_chembl4616_ec50(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL4616 EC50 dataset.
 
@@ -2513,7 +2513,7 @@ def load_chembl4792_ki(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ChEMBL4792 Ki dataset.
 

--- a/skfp/datasets/moleculenet/bace.py
+++ b/skfp/datasets/moleculenet/bace.py
@@ -19,7 +19,7 @@ def load_bace(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the BACE dataset.
 

--- a/skfp/datasets/moleculenet/bbbp.py
+++ b/skfp/datasets/moleculenet/bbbp.py
@@ -19,7 +19,7 @@ def load_bbbp(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the BBBP (Blood-Brain Barrier Penetration) dataset.
 

--- a/skfp/datasets/moleculenet/benchmark.py
+++ b/skfp/datasets/moleculenet/benchmark.py
@@ -167,7 +167,7 @@ def load_moleculenet_dataset(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load MoleculeNet dataset by name.
 

--- a/skfp/datasets/moleculenet/clintox.py
+++ b/skfp/datasets/moleculenet/clintox.py
@@ -19,7 +19,7 @@ def load_clintox(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the ClinTox dataset.
 

--- a/skfp/datasets/moleculenet/esol.py
+++ b/skfp/datasets/moleculenet/esol.py
@@ -19,7 +19,7 @@ def load_esol(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the ESOL (Estimated SOLubility) dataset.
 

--- a/skfp/datasets/moleculenet/freesolv.py
+++ b/skfp/datasets/moleculenet/freesolv.py
@@ -19,7 +19,7 @@ def load_freesolv(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the FreeSolv (Free Solvation Database) dataset.
 

--- a/skfp/datasets/moleculenet/hiv.py
+++ b/skfp/datasets/moleculenet/hiv.py
@@ -19,7 +19,7 @@ def load_hiv(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the HIV dataset.
 

--- a/skfp/datasets/moleculenet/lipophilicity.py
+++ b/skfp/datasets/moleculenet/lipophilicity.py
@@ -19,7 +19,7 @@ def load_lipophilicity(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Lipophilicity dataset.
 

--- a/skfp/datasets/moleculenet/muv.py
+++ b/skfp/datasets/moleculenet/muv.py
@@ -19,7 +19,7 @@ def load_muv(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the MUV (Maximum Unbiased Validation) dataset.
 

--- a/skfp/datasets/moleculenet/pcba.py
+++ b/skfp/datasets/moleculenet/pcba.py
@@ -19,7 +19,7 @@ def load_pcba(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the PCBA (PubChem BioAssay) dataset.
 

--- a/skfp/datasets/moleculenet/sider.py
+++ b/skfp/datasets/moleculenet/sider.py
@@ -19,7 +19,7 @@ def load_sider(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the SIDER (Side Effect Resource) dataset.
 

--- a/skfp/datasets/moleculenet/tox21.py
+++ b/skfp/datasets/moleculenet/tox21.py
@@ -19,7 +19,7 @@ def load_tox21(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Tox21 dataset.
 

--- a/skfp/datasets/moleculenet/toxcast.py
+++ b/skfp/datasets/moleculenet/toxcast.py
@@ -19,7 +19,7 @@ def load_toxcast(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the ToxCast dataset.
 

--- a/skfp/datasets/tdc/adme.py
+++ b/skfp/datasets/tdc/adme.py
@@ -19,7 +19,7 @@ def load_b3db_classification(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the classification subset of Blood-Brain-Barrier dataset.
 
@@ -101,7 +101,7 @@ def load_b3db_regression(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     r"""
     Load the regression subset of Blood-Brain-Barrier dataset.
 
@@ -181,7 +181,7 @@ def load_bioavailability_ma(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Bioavailability dataset.
 
@@ -254,7 +254,7 @@ def load_caco2_wang(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Caco-2 dataset.
 
@@ -326,7 +326,7 @@ def load_clearance_hepatocyte_az(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the hepatocyte subset of Clearance AstraZeneca dataset.
 
@@ -408,7 +408,7 @@ def load_clearance_microsome_az(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the microsome subset of Clearance AstraZeneca dataset.
 
@@ -490,7 +490,7 @@ def load_cyp1a2_veith(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP1A2 subset of CYP P450 Veith dataset.
 
@@ -574,7 +574,7 @@ def load_cyp2c9_substrate_carbonmangels(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP2C9 subset of Substrate Carbon-Mangels dataset.
 
@@ -658,7 +658,7 @@ def load_cyp2c9_veith(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP2C9 subset of CYP P450 Veith dataset.
 
@@ -739,7 +739,7 @@ def load_cyp2c19_veith(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP2C19 subset of CYP P450 Veith dataset.
 
@@ -821,7 +821,7 @@ def load_cyp2d6_substrate_carbonmangels(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP2D6 subset of Substrate Carbon-Mangels dataset.
 
@@ -906,7 +906,7 @@ def load_cyp2d6_veith(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP2D6 subset of CYP P450 Veith dataset.
 
@@ -988,7 +988,7 @@ def load_cyp3a4_substrate_carbonmangels(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP3A4 subset of Substrate Carbon-Mangels dataset.
 
@@ -1074,7 +1074,7 @@ def load_cyp3a4_veith(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the CYP3A4 subset of CYP P450 Veith dataset.
 
@@ -1157,7 +1157,7 @@ def load_half_life_obach(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Half Life Obach dataset.
 
@@ -1229,7 +1229,7 @@ def load_hia_hou(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Human Intestinal Absorption dataset.
 
@@ -1300,7 +1300,7 @@ def load_hlm(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the human subset of Human/Rat Liver Microsomal Stability dataset.
 
@@ -1373,7 +1373,7 @@ def load_pampa_approved_drugs(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the approved drugs subset of PAMPA dataset.
 
@@ -1446,7 +1446,7 @@ def load_pampa_ncats(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the NCATS subset of PAMPA dataset.
 
@@ -1519,7 +1519,7 @@ def load_pgp_broccatelli(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the P-gp (P-glycoprotein) Inhibition dataset.
 
@@ -1591,7 +1591,7 @@ def load_ppbr_az(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the PPBR (Plasma Protein Binding Rate) AstraZeneca dataset.
 
@@ -1664,7 +1664,7 @@ def load_rlm(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the rat subset of Human/Rat Liver Microsomal Stability dataset.
 
@@ -1737,7 +1737,7 @@ def load_solubility_aqsoldb(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Solubility AqSolDB dataset.
 
@@ -1809,7 +1809,7 @@ def load_vdss_lombardo(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Volume of Distribution at Steady State dataset.
 

--- a/skfp/datasets/tdc/benchmark.py
+++ b/skfp/datasets/tdc/benchmark.py
@@ -282,7 +282,7 @@ def load_tdc_dataset(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load TDC dataset by name.
 

--- a/skfp/datasets/tdc/hts.py
+++ b/skfp/datasets/tdc/hts.py
@@ -19,7 +19,7 @@ def load_sarscov2_3clpro_diamond(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the SARS-CoV-2 3CL Protease Diamond dataset.
 
@@ -86,7 +86,7 @@ def load_sarscov2_vitro_touret(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the SARSCoV2 Vitro Touret dataset.
 

--- a/skfp/datasets/tdc/tox.py
+++ b/skfp/datasets/tdc/tox.py
@@ -19,7 +19,7 @@ def load_ames(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the AMES dataset.
 
@@ -89,7 +89,7 @@ def load_carcinogens_lagunin(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Carcinogens dataset.
 
@@ -162,7 +162,7 @@ def load_dili(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the DILI (Drug Induced Liver Injury) dataset.
 
@@ -232,7 +232,7 @@ def load_herg(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the hERG blockers dataset.
 
@@ -302,7 +302,7 @@ def load_herg_central_at_1um(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the 1 µM subset of hERG Central dataset.
 
@@ -374,7 +374,7 @@ def load_herg_central_at_10um(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the 10 µM subset of hERG Central dataset.
 
@@ -446,7 +446,7 @@ def load_herg_central_inhib(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the inhibition subset of hERG Central dataset.
 
@@ -519,7 +519,7 @@ def load_herg_karim(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the hERG Karim dataset.
 
@@ -592,7 +592,7 @@ def load_ld50_zhu(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Acute Toxicity LD50 dataset.
 
@@ -662,7 +662,7 @@ def load_skin_reaction(
     data_dir: str | os.PathLike | None = None,
     as_frame: bool = False,
     verbose: bool = False,
-) -> pd.DataFrame | tuple[list[str]] | np.ndarray:
+) -> pd.DataFrame | tuple[list[str], np.ndarray]:
     """
     Load the Skin Reaction dataset.
 


### PR DESCRIPTION
## Changes

There was a typo in typing of return type in datasets loading. This PR fixes that.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
