### PR TITLE
InChI string support in ``ensure_mols``

### DIFF
--- a/skfp/utils/validators.py
+++ b/skfp/utils/validators.py
@@ -19,12 +19,11 @@ def ensure_mols(X: Sequence[Any]) -> list[Mol]:
             f"Passed values must be RDKit Mol objects, SMILES or InChI strings, got types: {types}"
         )
 
-    mols = []
-    for x in X:
-        if isinstance(x, str):
-            mols.append(MolFromInchi(x) if x.startswith("InChI=") else MolFromSmiles(x))
-        else:
-            mols.append(x)
+    if isinstance(X[0], str):
+        parser = MolFromInchi if X[0].startswith("InChI=") else MolFromSmiles
+        mols = [parser(x) for x in X]
+    else:
+        mols = list(X)
 
     if any(x is None for x in mols):
         idx = mols.index(None)

--- a/tests/utils/validators.py
+++ b/tests/utils/validators.py
@@ -29,7 +29,19 @@ def test_ensure_mols_wrong_smiles():
     assert "at index 1 as molecule" in str(exc_info)
 
 
-def test_ensure_mols_wrong_inchi():
+def test_ensure_mols_valid_inchi():
+    inchi_list = ["InChI=1S/H2O/h1H2", "InChI=1S/CH4/h1H4"]
+    mols = ensure_mols(inchi_list)
+    assert all(m is not None for m in mols)
+    assert len(mols) == 2
+    from rdkit.Chem import MolToSmiles
+
+    smiles = [MolToSmiles(m) for m in mols]
+    assert "O" in smiles
+    assert "C" in smiles
+
+
+def test_ensure_mols_invalid_inchi():
     inchi_list = ["InChI=1S/H2O/h1H2", "InChI=1S/invalid"]
     with pytest.raises(TypeError) as exc_info:
         ensure_mols(inchi_list)


### PR DESCRIPTION
## Changes

Call ``MolFromInchi`` from RDKit if an element of the input sequence to ensure_mols starts with "InChI=".

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
