### PR TITLE
Add multithreading to MolFromSDFTransformer [Issue 467]

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -9,6 +9,9 @@ from rdkit.Chem.PropertyMol import PropertyMol
 
 from skfp.bases import BasePreprocessor
 from skfp.utils import require_mols
+from skfp.utils.functions import _get_rdkit_version
+
+_MIN_MULTITHREADED_SDF_VERSION = (2025, 9, 1)
 
 
 class MolFromSDFTransformer(BasePreprocessor):
@@ -33,9 +36,8 @@ class MolFromSDFTransformer(BasePreprocessor):
 
     n_jobs : int, default=None
         The number of jobs to use when reading molecules from an SDF file path.
-        If ``n_jobs > 1`` and the installed RDKit supports
-        ``MultithreadedSDMolSupplier``, the file is read in parallel. Raw SDF text
-        input is always processed sequentially.
+        If ``n_jobs > 1`` and the installed RDKit version is at least ``2025.09.1``
+        the file is read in parallel. Raw SDF text input is always processed sequentially.
 
     References
     ----------
@@ -108,29 +110,18 @@ class MolFromSDFTransformer(BasePreprocessor):
 
     def _read_sdf_file(self, filepath: str) -> list[Mol]:
         n_jobs = effective_n_jobs(self.n_jobs)
+
         if n_jobs > 1:
-            try:
-                from rdkit.Chem import MultithreadedSDMolSupplier
-            except ImportError:
+            rdkit_version = _get_rdkit_version()
+            if rdkit_version < _MIN_MULTITHREADED_SDF_VERSION:
                 warnings.warn(
-                    "Parallel SDF reading is not available in the installed RDKit. "
+                    "Parallel SDF reading requires RDKit >= 2025.09.1. "
+                    f"Installed version is {'.'.join(map(str, rdkit_version))}. "
                     "Falling back to sequential loading."
                 )
             else:
-                with MultithreadedSDMolSupplier(
-                    filepath,
-                    sanitize=self.sanitize,
-                    removeHs=self.remove_hydrogens,
-                    numWriterThreads=n_jobs,
-                ) as supplier:
-                    mols_with_record_ids = [
-                        (supplier.GetLastRecordId(), mol) for mol in supplier
-                    ]
-                # sorting molecules to maintain the order from the file
-                mols_with_record_ids.sort(key=lambda item: item[0])
-                return [mol for _, mol in mols_with_record_ids]
+                return self._read_sdf_file_parallel(filepath, n_jobs)
 
-        # if problem with import or n_jobs == 1
         return list(
             SDMolSupplier(
                 filepath,
@@ -138,6 +129,24 @@ class MolFromSDFTransformer(BasePreprocessor):
                 removeHs=self.remove_hydrogens,
             )
         )
+
+    def _read_sdf_file_parallel(self, filepath: str, n_jobs: int) -> list[Mol]:
+        from rdkit.Chem import MultithreadedSDMolSupplier
+
+        with MultithreadedSDMolSupplier(
+            filepath,
+            sanitize=self.sanitize,
+            removeHs=self.remove_hydrogens,
+            numWriterThreads=n_jobs,
+        ) as supplier:
+            mols_with_record_ids = [
+                (supplier.GetLastRecordId(), mol)
+                for mol in supplier
+                if mol is not None  # multithreaded supplier may yield None duplicates
+            ]
+
+        mols_with_record_ids.sort(key=lambda item: item[0])
+        return [mol for _, mol in mols_with_record_ids]
 
     def _read_sdf_text(self, sdf_text: str) -> list[Mol]:
         if effective_n_jobs(self.n_jobs) > 1:

--- a/skfp/utils/functions.py
+++ b/skfp/utils/functions.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from importlib.metadata import version
 
 import pandas as pd
+from rdkit import rdBase
 
 
 def get_data_from_indices(data: Sequence, indices: Sequence[int]) -> list:
@@ -20,3 +21,13 @@ def _get_sklearn_version():
     sklearn_ver = version("scikit-learn")  # e.g. 1.6.0
     sklearn_ver = ".".join(sklearn_ver.split(".")[:2])  # e.g. 1.6
     return float(sklearn_ver)
+
+
+def _get_rdkit_version() -> tuple[int, int, int]:
+    # Unlike scikit-learn which uses float (broken for minor >= 10, e.g. 2025.1 == 2025.10),
+    # we return a tuple for correct ordering.
+    rdkit_ver = rdBase.rdkitVersion  # e.g. "2025.09.3"
+    parts = rdkit_ver.split(".")
+    if len(parts) < 3:
+        raise RuntimeError(f"Cannot parse RDKit version: {rdkit_ver}")
+    return int(parts[0]), int(parts[1]), int(parts[2])

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_equal
 from rdkit.Chem import Mol
 
 from skfp.preprocessing import MolFromSDFTransformer, MolToSDFTransformer
+from skfp.preprocessing.input_output import sdf as sdf_module
 
 
 @pytest.fixture
@@ -88,6 +89,20 @@ def test_mol_from_sdf_parallel_preserves_order(mols_list, tmp_path):
     parallel_names = [mol.GetProp("_Name") for mol in parallel_mols]
 
     assert parallel_names == sequential_names
+
+
+def test_mol_from_sdf_parallel_falls_back_for_older_rdkit(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(sdf_module, "_get_rdkit_version", lambda: (2025, 3, 0))
+    monkeypatch.setattr(
+        sdf_module, "SDMolSupplier", lambda *_args, **_kwargs: [sentinel]
+    )
+
+    mol_from_sdf = MolFromSDFTransformer(n_jobs=2)
+    with pytest.warns(UserWarning, match="requires RDKit >= 2025.09.1"):
+        mols = mol_from_sdf._read_sdf_file("ignored.sdf")
+
+    assert mols == [sentinel]
 
 
 def test_error_nonexistent_sdf_file():


### PR DESCRIPTION
This PR adds parallel SDF reading support in MolFromSDFTransformer when n_jobs > 1, using RDKit's MultithreadedSDMolSupplier (requires RDKit >= 2025.09.1).

Molecules loaded in parallel are sorted by record_id to preserve the original file order, and None results are filtered out to guard against nondeterministic duplicates from the multithreaded supplier.

When the installed RDKit version is too old or raw SDF text is passed instead of a file path, a warning is issued and loading falls back to sequential SDMolSupplier.

Additional changes:
- explicit RDKit version check via _get_rdkit_version() utility,
- parallel logic extracted into _read_sdf_file_parallel() for readability,
- tests covering parallel loading, order preservation, and version fallback.

https://github.com/scikit-fingerprints/scikit-fingerprints/issues/467
