### PR TITLE
Add Tanimoto scikit-fingerprints vs RDKit benchmark

### DIFF
--- a/benchmarking/tanimoto_comparison.py
+++ b/benchmarking/tanimoto_comparison.py
@@ -108,7 +108,7 @@ def benchmark_rdkit(smiles: list[str]) -> tuple[float, float]:
     """
     Compute pairwise Tanimoto similarity using RDKit.
     """
-    print("Benchmarking RDKIT...")
+    print("Benchmarking RDKit...")
     morgan_gen = GetMorganGenerator(radius=2, fpSize=2048)
 
     mols = [Chem.MolFromSmiles(s) for s in smiles]


### PR DESCRIPTION
## Changes

Implement SKFP vs RDKit benchmark comparing speed of the Tanimoto distance computation (pairwise).

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
