### PR TITLE
fix: add random_state to MHFPFingerprint/SECFPFingerprint; remove from BaseSubstructureFingerprint

### DIFF
--- a/skfp/bases/base_fp_transformer.py
+++ b/skfp/bases/base_fp_transformer.py
@@ -83,6 +83,13 @@ class BaseFingerprintTransformer(
         Controls the verbosity when computing fingerprints.
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
+
+    random_state : int or None, default=0
+        Controls the randomness of the fingerprint computation. Pass an integer
+        for reproducible results across multiple function calls. ``None`` means
+        that no fixed seed is used. Not all fingerprints use random numbers; for
+        those that do (e.g. :class:`MAPFingerprint`, :class:`MHFPFingerprint`,
+        :class:`SECFPFingerprint`) this parameter controls the hash seed.
     """
 
     # parameters common for all fingerprints

--- a/skfp/bases/base_substructure_fp.py
+++ b/skfp/bases/base_substructure_fp.py
@@ -70,7 +70,6 @@ class BaseSubstructureFingerprint(BaseFingerprintTransformer):
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
-        random_state: int | None = 0,
     ):
         super().__init__(
             n_features_out=len(patterns),
@@ -79,7 +78,6 @@ class BaseSubstructureFingerprint(BaseFingerprintTransformer):
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
-            random_state=random_state,
         )
         self.patterns = self._compile_smarts_patterns(patterns)
 

--- a/skfp/fingerprints/map.py
+++ b/skfp/fingerprints/map.py
@@ -80,6 +80,11 @@ class MAPFingerprint(BaseFingerprintTransformer):
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
 
+    random_state : int or None, default=0
+        Controls the randomness of the MinHash computation. Pass an integer
+        for reproducible results across multiple function calls. ``None`` means
+        that no fixed seed is used.
+
     Attributes
     ----------
     n_features_out : int

--- a/skfp/fingerprints/mhfp.py
+++ b/skfp/fingerprints/mhfp.py
@@ -74,6 +74,11 @@ class MHFPFingerprint(BaseFingerprintTransformer):
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
 
+    random_state : int or None, default=0
+        Controls the seed used when initializing the MinHash encoder. Pass an
+        integer for reproducible results across multiple function calls.
+        ``None`` means that no fixed seed is used.
+
     Attributes
     ----------
     n_features_out : int
@@ -136,6 +141,7 @@ class MHFPFingerprint(BaseFingerprintTransformer):
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
+        random_state: int | None = 0,
     ):
         super().__init__(
             n_features_out=fp_size,
@@ -143,6 +149,7 @@ class MHFPFingerprint(BaseFingerprintTransformer):
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
+            random_state=random_state,
         )
         self.fp_size = fp_size
         self.radius = radius

--- a/skfp/fingerprints/secfp.py
+++ b/skfp/fingerprints/secfp.py
@@ -67,6 +67,11 @@ class SECFPFingerprint(BaseFingerprintTransformer):
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
 
+    random_state : int or None, default=0
+        Controls the seed used when initializing the MinHash encoder. Pass an
+        integer for reproducible results across multiple function calls.
+        ``None`` means that no fixed seed is used.
+
     Attributes
     ----------
     n_features_out : int
@@ -127,6 +132,7 @@ class SECFPFingerprint(BaseFingerprintTransformer):
         n_jobs: int | None = None,
         batch_size: int | None = None,
         verbose: int | dict = 0,
+        random_state: int | None = 0,
     ):
         super().__init__(
             n_features_out=fp_size,
@@ -134,6 +140,7 @@ class SECFPFingerprint(BaseFingerprintTransformer):
             n_jobs=n_jobs,
             batch_size=batch_size,
             verbose=verbose,
+            random_state=random_state,
         )
         self.fp_size = fp_size
         self.radius = radius

--- a/skfp/model_selection/hyperparam_search/randomized_search.py
+++ b/skfp/model_selection/hyperparam_search/randomized_search.py
@@ -83,6 +83,11 @@ class FingerprintEstimatorRandomizedSearch(BaseEstimator):
         If a dictionary is passed, it is treated as kwargs for ``tqdm()``,
         and can be used to control the progress bar.
 
+    random_state : int or None, default=0
+        Controls the random seed used when sampling fingerprint hyperparameter
+        combinations. Pass an integer for reproducible selections across multiple
+        function calls. ``None`` means that no fixed seed is used.
+
     Attributes
     ----------
     cv_results_ : list[dict]

--- a/tests/bases/base_substructure_fp.py
+++ b/tests/bases/base_substructure_fp.py
@@ -151,3 +151,15 @@ def test_empty_patterns_list(substructure_smiles_list: list[str]):
     assert str(error.value).startswith(
         "The 'patterns' parameter must be a non-empty list of SMARTS patterns."
     )
+
+
+def test_base_substructure_fp_no_random_state():
+    """Regression test for GitHub issue #531: BaseSubstructureFingerprint
+    does not use random_state internally, so it should not expose it as a
+    constructor parameter (to avoid misleading the user)."""
+    fp = BaseSubstructureFingerprint(["[OH]"])
+    params = fp.get_params()
+    assert "random_state" not in params, (
+        "BaseSubstructureFingerprint should not expose random_state since it "
+        "does not use any randomness. Got params: %s" % list(params.keys())
+    )

--- a/tests/fingerprints/map.py
+++ b/tests/fingerprints/map.py
@@ -213,3 +213,15 @@ def test_map_chirality_uses_substructure():
 
     # with chirality enabled, enantiomers should produce different fingerprints
     assert not np.array_equal(fp_l, fp_d)
+
+
+def test_map_random_state_parameter(smiles_list):
+    """Regression test for GitHub issue #531: random_state must be an explicit
+    constructor parameter so it appears in repr() and get_params()."""
+    fp_default = MAPFingerprint()
+
+    assert "random_state" in fp_default.get_params()
+    assert fp_default.get_params()["random_state"] == 0
+
+    fp_seeded = MAPFingerprint(random_state=42)
+    assert fp_seeded.get_params()["random_state"] == 42

--- a/tests/fingerprints/mhfp.py
+++ b/tests/fingerprints/mhfp.py
@@ -111,3 +111,23 @@ def test_mhfp_wrong_radii(smiles_list):
     mhfp_fp = MHFPFingerprint(min_radius=3, radius=2)
     with pytest.raises(InvalidParameterError):
         mhfp_fp.transform(smiles_list)
+
+
+def test_mhfp_random_state_parameter(smiles_list):
+    """Regression test for GitHub issue #531: random_state must be an explicit
+    constructor parameter (not just inherited silently) so that it appears in
+    repr() and can be retrieved via get_params()."""
+    fp_default = MHFPFingerprint()
+    fp_seeded = MHFPFingerprint(random_state=42)
+    fp_none = MHFPFingerprint(random_state=None)
+
+    # random_state must appear in get_params()
+    assert "random_state" in fp_default.get_params()
+    assert fp_default.get_params()["random_state"] == 0
+    assert fp_seeded.get_params()["random_state"] == 42
+    assert fp_none.get_params()["random_state"] is None
+
+    # Two runs with the same seed must produce identical results
+    X1 = MHFPFingerprint(random_state=0).transform(smiles_list)
+    X2 = MHFPFingerprint(random_state=0).transform(smiles_list)
+    assert_equal(X1, X2)

--- a/tests/fingerprints/secfp.py
+++ b/tests/fingerprints/secfp.py
@@ -38,3 +38,23 @@ def test_secfp_wrong_radii(smiles_list):
     secfp_fp = SECFPFingerprint(min_radius=3, radius=2)
     with pytest.raises(InvalidParameterError):
         secfp_fp.transform(smiles_list)
+
+
+def test_secfp_random_state_parameter(smiles_list):
+    """Regression test for GitHub issue #531: random_state must be an explicit
+    constructor parameter (not just inherited silently) so that it appears in
+    repr() and can be retrieved via get_params()."""
+    fp_default = SECFPFingerprint()
+    fp_seeded = SECFPFingerprint(random_state=42)
+    fp_none = SECFPFingerprint(random_state=None)
+
+    # random_state must appear in get_params()
+    assert "random_state" in fp_default.get_params()
+    assert fp_default.get_params()["random_state"] == 0
+    assert fp_seeded.get_params()["random_state"] == 42
+    assert fp_none.get_params()["random_state"] is None
+
+    # Two runs with the same seed must produce identical results
+    X1 = SECFPFingerprint(random_state=0).transform(smiles_list)
+    X2 = SECFPFingerprint(random_state=0).transform(smiles_list)
+    assert_equal(X1, X2)


### PR DESCRIPTION
## Summary

Fixes #531

### Problems

**1. `MHFPFingerprint` and `SECFPFingerprint`** each use `self.random_state` internally when initializing `MHFPEncoder`, but neither class declared `random_state` as an explicit `__init__` parameter. This meant the parameter was invisible in `repr()`, `get_params()`, and the class docstring — users had no way to know they could control the seed.

**2. `BaseSubstructureFingerprint`** accepted a `random_state` parameter that was silently forwarded to the base class but never actually used by the class or any of its subclasses (`GhoseCrippen`, `Laggner`, `KlekotaRoth`). This misleadingly suggested the parameter had an effect.

### Changes

| File | Change |
|------|--------|
| `skfp/fingerprints/mhfp.py` | Add `random_state` to `__init__` + docstring |
| `skfp/fingerprints/secfp.py` | Add `random_state` to `__init__` + docstring |
| `skfp/bases/base_substructure_fp.py` | Remove `random_state` parameter |
| `skfp/bases/base_fp_transformer.py` | Add `random_state` docstring entry |
| `skfp/fingerprints/map.py` | Add `random_state` docstring entry |
| `skfp/model_selection/.../randomized_search.py` | Add `random_state` docstring entry |

### Tests

- `test_mhfp_random_state_parameter`: verifies `get_params()` exposes `random_state` and two runs with the same seed produce identical results
- `test_secfp_random_state_parameter`: same for `SECFPFingerprint`
- `test_map_random_state_parameter`: verifies `get_params()` includes `random_state`
- `test_base_substructure_fp_no_random_state`: asserts `random_state` is absent from `BaseSubstructureFingerprint.get_params()`