### PR TITLE
Add Zagreb Index and Wiener Index to Mordred

### DIFF
--- a/skfp/descriptors/topological.py
+++ b/skfp/descriptors/topological.py
@@ -633,13 +633,13 @@ def zagreb_index_m1(
 
     modified : bool, default=False
         Whether to use the modified Zagreb index. If True, the modified Zagreb index
-        is calculated.
+        is calculated. Returns ``np.nan`` when True and the molecule contains at
+        least one atom with degree 0.
 
     Returns
     -------
     float
-        Descriptor value. Returns ``np.nan`` when ``modified=True`` and the molecule
-        contains at least one atom with degree 0.
+        Descriptor value.
 
     References
     ----------
@@ -706,13 +706,13 @@ def zagreb_index_m2(
 
     modified : bool, default=False
         Whether to use the modified Zagreb index. If True, the modified Zagreb index
-        is calculated.
+        is calculated. Returns ``np.nan`` when True and the molecule contains at
+        least one atom with degree 0.
 
     Returns
     -------
     float
-        Descriptor value. Returns ``np.nan`` when ``modified=True`` and the molecule
-        contains at least one atom with degree 0.
+        Descriptor value.
 
     References
     ----------

--- a/skfp/descriptors/topological.py
+++ b/skfp/descriptors/topological.py
@@ -611,7 +611,11 @@ def wiener_index(mol: Mol, distance_matrix: np.ndarray | None = None) -> int:
     return int(np.sum(distance_matrix) // 2)
 
 
-def zagreb_index_m1(mol: Mol) -> int:
+def zagreb_index_m1(
+    mol: Mol,
+    degree_vector: np.ndarray[np.floating] | None = None,
+    modified: bool = False,
+) -> float:
     """
     First Zagreb Index.
 
@@ -623,6 +627,19 @@ def zagreb_index_m1(mol: Mol) -> int:
     ----------
     mol : RDKit ``Mol`` object
         The molecule for which the first Zagreb index is to be calculated.
+
+    degree_vector : np.ndarray, default=None
+        Precomputed degrees of all atoms in the molecule. If not provided, it will be calculated.
+
+    modified : bool, default=False
+        Whether to use the modified Zagreb index. If True, the modified Zagreb index
+        is calculated.
+
+    Returns
+    -------
+    float
+        Descriptor value. Returns ``np.nan`` when ``modified=True`` and the molecule
+        contains at least one atom with degree 0.
 
     References
     ----------
@@ -639,10 +656,28 @@ def zagreb_index_m1(mol: Mol) -> int:
     >>> zagreb_index_m1(mol)
     24
     """
-    return int(sum(atom.GetDegree() ** 2 for atom in mol.GetAtoms()))
+    exponent = -2 if modified else 2
+
+    if degree_vector is None:
+        degree_vector = np.array(
+            [atom.GetDegree() for atom in mol.GetAtoms()], dtype=float
+        )
+
+    if modified and np.any(degree_vector == 0):
+        return np.nan
+
+    with np.errstate(divide="raise", invalid="raise"):
+        try:
+            return float((degree_vector**exponent).sum())
+        except (FloatingPointError, ZeroDivisionError):
+            return np.nan
 
 
-def zagreb_index_m2(mol: Mol) -> int:
+def zagreb_index_m2(
+    mol: Mol,
+    degree_vector: np.ndarray[np.floating] | None = None,
+    modified: bool = False,
+) -> float:
     r"""
     Second Zagreb Index.
 
@@ -666,6 +701,19 @@ def zagreb_index_m2(mol: Mol) -> int:
     mol : RDKit ``Mol`` object
         The molecule for which the second Zagreb index is to be calculated.
 
+    degree_vector : np.ndarray, default=None
+        Precomputed degrees of all atoms in the molecule. If not provided, it will be calculated.
+
+    modified : bool, default=False
+        Whether to use the modified Zagreb index. If True, the modified Zagreb index
+        is calculated.
+
+    Returns
+    -------
+    float
+        Descriptor value. Returns ``np.nan`` when ``modified=True`` and the molecule
+        contains at least one atom with degree 0.
+
     References
     ----------
     .. [1] `Gutman, Ivan.
@@ -681,10 +729,29 @@ def zagreb_index_m2(mol: Mol) -> int:
     >>> zagreb_index_m2(mol)
     24
     """
-    return int(
-        sum(
-            mol.GetAtomWithIdx(bond.GetBeginAtomIdx()).GetDegree()
-            * mol.GetAtomWithIdx(bond.GetEndAtomIdx()).GetDegree()
-            for bond in mol.GetBonds()
+    exponent = -1 if modified else 1
+
+    if degree_vector is None:
+        degree_vector = np.array(
+            [atom.GetDegree() for atom in mol.GetAtoms()], dtype=float
         )
-    )
+
+    if modified and np.any(degree_vector == 0):
+        return np.nan
+
+    with np.errstate(divide="raise", invalid="raise"):
+        try:
+            return float(
+                sum(
+                    (
+                        (
+                            degree_vector[bond.GetBeginAtomIdx()]
+                            * degree_vector[bond.GetEndAtomIdx()]
+                        )
+                        ** exponent
+                    )
+                    for bond in mol.GetBonds()
+                )
+            )
+        except (FloatingPointError, ZeroDivisionError):
+            return np.nan

--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -10,12 +10,19 @@
 import numpy as np
 from rdkit.Chem import GetMolFrags, Mol
 
-from skfp.fingerprints._new_mordred.descriptors import abc_index
+from skfp.fingerprints._new_mordred.descriptors import (
+    abc_index,
+    wiener_index,
+    zagreb_index,
+)
 from skfp.fingerprints._new_mordred.utils.feature_names import (
     ALL_FEATURE_NAMES,
     FEATURE_NAMES_2D,
 )
-from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
+from skfp.fingerprints._new_mordred.utils.graph_matrix import (
+    AdjacencyMatrix,
+    DistanceMatrix,
+)
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
 
 _FEATURE_NAME_TO_IDX_2D = {name: i for i, name in enumerate(FEATURE_NAMES_2D)}
@@ -40,10 +47,13 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
 
     mol_regular = preprocess_mol(mol)
     distance_matrix_regular = DistanceMatrix(mol_regular)
+    adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
 
     # 2D descriptors
     descriptors_2d = [
         abc_index.calc(mol_regular, distance_matrix_regular),
+        wiener_index.calc(mol_regular, distance_matrix_regular),
+        zagreb_index.calc(mol_regular, adjacency_matrix_regular),
     ]
 
     for values, feature_names in descriptors_2d:

--- a/skfp/fingerprints/_new_mordred/descriptors/wiener_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/wiener_index.py
@@ -1,0 +1,27 @@
+import numpy as np
+from rdkit.Chem import Mol
+
+from skfp.descriptors import polarity_number, wiener_index
+from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = ["WPath", "WPol"]
+
+
+def calc(
+    mol_regular: Mol, distance_matrix_regular: DistanceMatrix
+) -> tuple[np.ndarray, list[str]]:
+    values = np.array(
+        [
+            wiener_index(mol_regular, distance_matrix_regular.matrix),
+            polarity_number(mol_regular, distance_matrix_regular.matrix),
+        ],
+        dtype=np.float32,
+    )
+    return values, FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/zagreb_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/zagreb_index.py
@@ -1,0 +1,37 @@
+import numpy as np
+from rdkit.Chem import Mol
+
+from skfp.descriptors import zagreb_index_m1, zagreb_index_m2
+from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = ["Zagreb1", "Zagreb2", "mZagreb1", "mZagreb2"]
+
+
+def calc(
+    mol_regular: Mol, adjacency_matrix_regular: AdjacencyMatrix
+) -> tuple[np.ndarray, list[str]]:
+    values = np.array(
+        [
+            zagreb_index_m1(mol_regular, degree_vector=adjacency_matrix_regular.degree),
+            zagreb_index_m2(mol_regular, degree_vector=adjacency_matrix_regular.degree),
+            zagreb_index_m1(
+                mol_regular,
+                degree_vector=adjacency_matrix_regular.degree,
+                modified=True,
+            ),
+            zagreb_index_m2(
+                mol_regular,
+                degree_vector=adjacency_matrix_regular.degree,
+                modified=True,
+            ),
+        ],
+        dtype=np.float32,
+    )
+    return values, FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
+++ b/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
@@ -58,7 +58,7 @@ class AdjacencyMatrix:
         bond counts as one edge. In that case, atom degree equals the atom
         valence, i.e. the number of bonds each atom forms.
         """
-        return self._base.sum(axis=0)
+        return self._base.sum(axis=0, dtype=float)
 
 
 class DistanceMatrix3D:

--- a/tests/descriptors/topological.py
+++ b/tests/descriptors/topological.py
@@ -338,6 +338,18 @@ def test_zagreb_index_m2(mol_name, expected_value, input_mols):
     assert_equal(result, expected_value)
 
 
+def test_modified_zagreb_index_m1_returns_nan_for_zero_valence(input_mols):
+    mol, _ = input_mols["sulfur"]
+    result = top.zagreb_index_m1(mol, modified=True)
+    assert np.isnan(result)
+
+
+def test_modified_zagreb_index_m2_returns_nan_for_zero_valence(input_mols):
+    mol, _ = input_mols["sulfur"]
+    result = top.zagreb_index_m2(mol, modified=True)
+    assert np.isnan(result)
+
+
 @pytest.mark.parametrize(
     "mol_name, expected_value",
     {


### PR DESCRIPTION
**Descriptor Function Enhancements:**

* Refactored `zagreb_index_m1` and `zagreb_index_m2` in `skfp/descriptors/topological.py` to accept optional precomputed degree vectors and a `modified` flag, enabling calculation of both standard and modified Zagreb indices. The functions now return `np.nan` when the modified index is requested and the molecule contains atoms with zero degree, and raise fewer errors by handling floating point and division issues internally. [[1]](diffhunk://#diff-34f006d76fdb9cd89ef43d04be6e7be207811447a1da339973e1ff1557ae9bcbL614-R618) [[2]](diffhunk://#diff-34f006d76fdb9cd89ef43d04be6e7be207811447a1da339973e1ff1557ae9bcbR631-R643) [[3]](diffhunk://#diff-34f006d76fdb9cd89ef43d04be6e7be207811447a1da339973e1ff1557ae9bcbL642-R680) [[4]](diffhunk://#diff-34f006d76fdb9cd89ef43d04be6e7be207811447a1da339973e1ff1557ae9bcbR704-R716) [[5]](diffhunk://#diff-34f006d76fdb9cd89ef43d04be6e7be207811447a1da339973e1ff1557ae9bcbL684-R757)

**New Descriptor Modules:**

* Added new modules `skfp/fingerprints/_new_mordred/descriptors/wiener_index.py` and `skfp/fingerprints/_new_mordred/descriptors/zagreb_index.py` that provide functions to calculate the Wiener and both standard/modified Zagreb indices, integrating with the new matrix utilities and returning results in the expected Mordred-like format. [[1]](diffhunk://#diff-e6f4a21d732e5486d12682f276bfd16683e6c52e6b6561cb2c2b30e202e46e4bR1-R27) [[2]](diffhunk://#diff-2bc45b44edbcb03665e7bc0839a70eabb3078a4d9e2119de9cf122308d085f90R1-R37)

**Integration with Fingerprint Calculation:**

* Updated `skfp/fingerprints/_new_mordred/calculator.py` to import and use the new Wiener and Zagreb index descriptor functions. The calculator now computes and includes these descriptors using the appropriate distance and adjacency matrices. [[1]](diffhunk://#diff-9a19a59b9214faf497fc2bec2e687b649a8d7d3d5ca74b6a26f3fae8ff88f346L13-R25) [[2]](diffhunk://#diff-9a19a59b9214faf497fc2bec2e687b649a8d7d3d5ca74b6a26f3fae8ff88f346R50-R56)

**Matrix Utility Improvements:**

* Modified the `degree` property of `AdjacencyMatrix` in `skfp/fingerprints/_new_mordred/utils/graph_matrix.py` to always return a float array, ensuring compatibility with the updated descriptor functions.

**Testing:**

* Added tests in `tests/descriptors/topological.py` to verify that the modified Zagreb indices return `np.nan` for molecules containing atoms with zero valence, improving coverage of edge cases.
