### PR TITLE
fix(filters): always return np.ndarray from filter indicators (#557)

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -274,6 +274,12 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
 
         if self.return_type == "condition_indicators":
             filter_indicators = np.vstack(filter_indicators)
+        elif not isinstance(filter_indicators, np.ndarray):
+            # run_in_parallel returns a Python list when flatten_results=True;
+            # the return contract of this method (and the caller's typing) is
+            # np.ndarray, so wrap it. Single-job and verbose paths above
+            # already produce ndarrays directly.
+            filter_indicators = np.asarray(filter_indicators, dtype=bool)
 
         return filter_indicators
 

--- a/tests/bases/base_filter.py
+++ b/tests/bases/base_filter.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
@@ -37,3 +38,18 @@ def test_base_verbose(n_jobs, smiles_list, capsys):
     output = capsys.readouterr().err
     assert "100%" in output
     assert "it/s" in output
+
+
+@pytest.mark.parametrize("n_jobs", [1, 2])
+def test_indicators_are_ndarray(n_jobs, smiles_list):
+    """Filter indicators must be np.ndarray regardless of n_jobs (#557).
+
+    Previously the multi-job path returned a Python list because
+    run_in_parallel(flatten_results=True) yields a list and the
+    per-condition vstack only ran for the condition_indicators branch.
+    """
+    filt = LipinskiFilter(n_jobs=n_jobs, return_type="indicators")
+    out = filt.transform(smiles_list)
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == bool
+    assert out.shape == (len(smiles_list),)


### PR DESCRIPTION
Closes #557.

## What changed

\`BaseFilter._get_filter_indicators\` (\`skfp/bases/base_filter.py\`) now coerces the result to \`np.ndarray\` in the multi-job, non-\`condition_indicators\` path. Mirrors the existing \`np.vstack\` branch for \`condition_indicators\`.

## Why this matters

The path that breaks is:

\`\`\`python
filter_indicators = run_in_parallel(
    self._filter_mols_batch,
    ...,
    flatten_results=True,
)

if self.return_type == "condition_indicators":
    filter_indicators = np.vstack(filter_indicators)

return filter_indicators
\`\`\`

\`run_in_parallel(flatten_results=True)\` returns a Python \`list\`, not an \`ndarray\`. The \`condition_indicators\` branch wraps it; the \`indicators\` branch did not. Method's \`-> np.ndarray\` annotation and every caller (\`transform\`, \`transform_x_y\`) treat the return as ndarray. The drift was silent because both list and ndarray support the indexing/iteration the callers actually used.

After the patch, \`return_type="indicators"\` returns \`np.ndarray\` of \`dtype=bool\` for both \`n_jobs=1\` and \`n_jobs>1\`, matching what the single-job path's \`_filter_mols_batch\` already produces.

## Verification

Added a regression test in \`tests/bases/base_filter.py\`:

\`\`\`python
@pytest.mark.parametrize("n_jobs", [1, 2])
def test_indicators_are_ndarray(n_jobs, smiles_list):
    filt = LipinskiFilter(n_jobs=n_jobs, return_type="indicators")
    out = filt.transform(smiles_list)
    assert isinstance(out, np.ndarray)
    assert out.dtype == bool
    assert out.shape == (len(smiles_list),)
\`\`\`

Both modules pass \`ast.parse\`. CI in this repo will exercise the parallel path against the actual joblib runtime — no local pytest run because the dev environment isn't bootstrapped here.