### PR TITLE
fix: ensure filter_indicators always returns np.ndarray

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -274,6 +274,8 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
 
         if self.return_type == "condition_indicators":
             filter_indicators = np.vstack(filter_indicators)
+        elif not isinstance(filter_indicators, np.ndarray):
+            filter_indicators = np.array(filter_indicators, dtype=bool)
 
         return filter_indicators
 


### PR DESCRIPTION
## Summary

When `n_jobs > 1`, `run_in_parallel()` returns a plain `list`, not `np.ndarray`. This caused `_get_filter_indicators()` to return a list instead of `np.ndarray` when `return_type` was `'indicators'`.

### Problem

The issue states: "Filter indicators should always be a `np.ndarray()`, whereas now they are returned with the same type as the input."

The root cause is in `_get_filter_indicators()`: when parallel execution is used (`n_jobs > 1`), `run_in_parallel()` with `flatten_results=True` returns a flat `list`. For `return_type='condition_indicators'`, there's already a `np.vstack()` call that converts back to ndarray. But for `return_type='indicators'`, the list was returned as-is.

### Fix

Add an `isinstance` check after parallel execution: if the result is not already `np.ndarray`, convert it with `np.array(filter_indicators, dtype=bool)`.

### Before
```python
# With n_jobs > 1, return_type='indicators':
filter_ind = filter.transform(X)
type(filter_ind)  # <class 'list'> ← wrong!
```

### After
```python
# Always:
filter_ind = filter.transform(X)
type(filter_ind)  # <class 'numpy.ndarray'> ✓
```

Fixes #557