### PR TITLE
fix: return arrays for parallel filter indicators

### DIFF
--- a/skfp/bases/base_filter.py
+++ b/skfp/bases/base_filter.py
@@ -274,6 +274,8 @@ class BaseFilter(ABC, BaseEstimator, TransformerMixin):
 
         if self.return_type == "condition_indicators":
             filter_indicators = np.vstack(filter_indicators)
+        else:
+            filter_indicators = np.asarray(filter_indicators, dtype=bool)
 
         return filter_indicators
 

--- a/tests/bases/base_filter.py
+++ b/tests/bases/base_filter.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
@@ -37,3 +38,12 @@ def test_base_verbose(n_jobs, smiles_list, capsys):
     output = capsys.readouterr().err
     assert "100%" in output
     assert "it/s" in output
+
+
+def test_base_parallel_filter_indicators_return_array(smiles_list):
+    filt = LipinskiFilter(return_type="indicators", n_jobs=2, batch_size=1)
+
+    filter_indicators = filt.transform(smiles_list)
+
+    assert isinstance(filter_indicators, np.ndarray)
+    assert np.issubdtype(filter_indicators.dtype, bool)


### PR DESCRIPTION
## Summary
- normalize non-condition filter indicators to a NumPy boolean array after the parallel path
- add regression coverage for parallel indicator output type

Fixes #557

## Validation
- uv run pytest tests/bases/base_filter.py -q
- uv run ruff check skfp/bases/base_filter.py tests/bases/base_filter.py
- uv run ruff format --check skfp/bases/base_filter.py tests/bases/base_filter.py
- git diff --check