### PR TITLE
Migrate ReadTheDocs build to uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,3 +69,5 @@ jobs:
 
       - name: Run docstring tests
         run: uv run make -C docs doctest
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}  # faster datasets download

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Run tests with pytest
         run: uv run make test
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}  # faster datasets download
 
       - name: Run docstring tests
         run: uv run make -C docs doctest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,12 @@
 version: 2
+formats: [htmlzip]
+sphinx:
+   configuration: docs/conf.py
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.10"
 
 python:
   install:
@@ -6,13 +14,3 @@ python:
       command: sync
       groups:
         - docs
-
-build:
-  os: ubuntu-24.04
-  tools:
-    python: "3.10"
-  jobs:
-    build:
-      html:
-        - uv run make -C docs html SPHINXBUILD="uv run sphinx-build"
-        - cp -r docs/_build/html $READTHEDOCS_OUTPUT

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,5 @@ build:
       html:
         - echo $READTHEDOCS_OUTPUT/html/
         - mkdir -p $READTHEDOCS_OUTPUT/html/
-        - make -C docs html
+        - uv run make -C docs html
         - cp -r docs/_build/html $READTHEDOCS_OUTPUT

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,18 +1,17 @@
 version: 2
 
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs
+
 build:
   os: ubuntu-24.04
   tools:
     python: "3.10"
   jobs:
-    pre_create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-    create_environment:
-       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-    install:
-       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" uv sync --frozen --group docs --extra neural
     build:
       html:
         - echo $READTHEDOCS_OUTPUT/html/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,5 @@ build:
   jobs:
     build:
       html:
-        - echo $READTHEDOCS_OUTPUT/html/
-        - mkdir -p $READTHEDOCS_OUTPUT/html/
-        - uv run make -C docs html
+        - uv run make -C docs html SPHINXBUILD="uv run sphinx-build"
         - cp -r docs/_build/html $READTHEDOCS_OUTPUT

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,5 @@
 version: 2
 formats: [htmlzip]
-sphinx:
-   configuration: docs/conf.py
 
 build:
   os: ubuntu-24.04
@@ -14,3 +12,6 @@ python:
       command: sync
       groups:
         - docs
+
+sphinx:
+   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,8 @@ extensions = [
     "nbsphinx",
 ]
 
+autodoc_mock_imports = ["torch"]
+
 autodoc_default_options = {
     "inherited-members": True,
     "members": "fit,fit_transform,transform",
@@ -65,6 +67,7 @@ html_theme_options = {
 }
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
+
 
 # Sphinx cannot reach outside to parallel dirs, so we copy "examples" directory
 # we copy "examples" directory from project root to docs/examples


### PR DESCRIPTION
## Changes

Covers https://github.com/MLCIL/scikit-fingerprints/issues/556, moving ReadTheDocs building to uv. Also optimizes the build process to be faster.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
