### PR TITLE
Add Mordred WalkCount descriptor

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -13,6 +13,7 @@ from rdkit.Chem import GetMolFrags, Mol
 from skfp.fingerprints._new_mordred.descriptors import (
     abc_index,
     acid_base,
+    walk_count,
     wiener_index,
     zagreb_index,
 )
@@ -53,6 +54,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     # 2D descriptors
     descriptors_2d = [
         abc_index.calc(mol_regular, distance_matrix_regular),
+        walk_count.calc(mol_regular, adjacency_matrix_regular),
         wiener_index.calc(mol_regular, distance_matrix_regular),
         zagreb_index.calc(mol_regular, adjacency_matrix_regular),
         acid_base.calc(mol_regular),

--- a/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
@@ -1,5 +1,6 @@
 import numpy as np
 from rdkit.Chem import Mol
+
 from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
 
 """

--- a/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
@@ -1,0 +1,64 @@
+import numpy as np
+from rdkit.Chem import Mol
+from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = [
+    # Molecular Walk Count
+    "MWC01",
+    "MWC02",
+    "MWC03",
+    "MWC04",
+    "MWC05",
+    "MWC06",
+    "MWC07",
+    "MWC08",
+    "MWC09",
+    "MWC10",
+    # Total MWC
+    "TMWC10",
+    # Self-Returning Walk
+    "SRW02",
+    "SRW03",
+    "SRW04",
+    "SRW05",
+    "SRW06",
+    "SRW07",
+    "SRW08",
+    "SRW09",
+    "SRW10",
+    # Total SRW
+    "TSRW10",
+]
+
+def calc(mol: Mol, adjacency_matrix: AdjacencyMatrix) -> tuple[np.ndarray, list[str]]:
+    adjacency = adjacency_matrix.order().astype(np.float64)
+
+    power = adjacency
+    molecular_walk_counts: list[float] = []
+    self_returning_walk_counts: list[float] = []
+
+    for num_order in range(1, 11):
+        if num_order > 1:
+            power = adjacency_matrix.order(num_order).astype(np.float64)
+
+        if num_order == 1:
+            molecular_walk_counts.append(0.5 * float(power.sum()))
+        else:
+            molecular_walk_counts.append(np.log(float(power.sum()) + 1))
+            self_returning_walk_counts.append(np.log(float(np.trace(power)) + 1))
+
+    values = [
+        *molecular_walk_counts,
+        mol.GetNumAtoms() + sum(molecular_walk_counts),
+        *self_returning_walk_counts,
+        mol.GetNumAtoms() + sum(self_returning_walk_counts),
+    ]
+
+    return np.asarray(values, dtype=np.float32), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
@@ -37,16 +37,15 @@ FEATURE_NAMES = [
     "TSRW10",
 ]
 
-def calc(mol: Mol, adjacency_matrix: AdjacencyMatrix) -> tuple[np.ndarray, list[str]]:
-    adjacency = adjacency_matrix.order().astype(np.float64)
 
-    power = adjacency
+def calc(mol: Mol, adjacency_matrix: AdjacencyMatrix) -> tuple[np.ndarray, list[str]]:
+    power = adjacency_matrix.order()
     molecular_walk_counts: list[float] = []
     self_returning_walk_counts: list[float] = []
 
     for num_order in range(1, 11):
         if num_order > 1:
-            power = adjacency_matrix.order(num_order).astype(np.float64)
+            power = adjacency_matrix.order(num_order)
 
         if num_order == 1:
             molecular_walk_counts.append(0.5 * float(power.sum()))

--- a/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
+++ b/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
@@ -43,7 +43,6 @@ class AdjacencyMatrix:
         self._base = GetAdjacencyMatrix(mol, useBO=use_bond_orders)
         self._orders = [self._base]
 
-    # TODO(Aleksander Jóźwik): check if caching all intermediate orders is necessary or if # noqa: TD003, FIX002
     # WalkCount can be simplified to avoid the extra memory usage
     def order(self, n: int = 1) -> np.ndarray:
         while len(self._orders) < n:

--- a/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
+++ b/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
@@ -43,7 +43,6 @@ class AdjacencyMatrix:
         self._base = GetAdjacencyMatrix(mol, useBO=use_bond_orders)
         self._orders = [self._base]
 
-    # WalkCount can be simplified to avoid the extra memory usage
     def order(self, n: int = 1) -> np.ndarray:
         while len(self._orders) < n:
             self._orders.append(self._orders[-1].dot(self._base))


### PR DESCRIPTION
This pull request introduces the new `walk_count` descriptor to the NewMordred fingerprint calculation.

New Features:

Added the `walk_count` descriptor, which computes 21 topological walk-based features: molecular walk counts (MWC01–MWC10), their cumulative total (`TMWC10`), self-returning walk counts (`SRW02`–`SRW10`), and their cumulative total (`TSRW10`). These descriptors encode the structural complexity of a molecule by counting paths of increasing length in the molecular graph, derived from successive powers of the adjacency matrix.

## Checklist before requesting a review
- [ ] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
