### PR TITLE
Add Mordred AdjacencyMatrix descriptor

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -14,6 +14,7 @@ from skfp.fingerprints._new_mordred.descriptors import (
     abc_index,
     acid_base,
     walk_count,
+    adjacency_matrix,
     wiener_index,
     zagreb_index,
 )
@@ -45,7 +46,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     result = np.full(n_features, np.nan, dtype=np.float32)
 
     # dependencies
-    n_frags = len(GetMolFrags(mol))  # noqa: F841
+    n_frags = len(GetMolFrags(mol))  
 
     mol_regular = preprocess_mol(mol)
     distance_matrix_regular = DistanceMatrix(mol_regular)
@@ -55,6 +56,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     descriptors_2d = [
         abc_index.calc(mol_regular, distance_matrix_regular),
         walk_count.calc(mol_regular, adjacency_matrix_regular),
+        adjacency_matrix.calc(mol_regular, n_frags, adjacency_matrix_regular),
         wiener_index.calc(mol_regular, distance_matrix_regular),
         zagreb_index.calc(mol_regular, adjacency_matrix_regular),
         acid_base.calc(mol_regular),

--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -46,7 +46,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     result = np.full(n_features, np.nan, dtype=np.float32)
 
     # dependencies
-    n_frags = len(GetMolFrags(mol))  
+    n_frags = len(GetMolFrags(mol))
 
     mol_regular = preprocess_mol(mol)
     distance_matrix_regular = DistanceMatrix(mol_regular)

--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -13,8 +13,8 @@ from rdkit.Chem import GetMolFrags, Mol
 from skfp.fingerprints._new_mordred.descriptors import (
     abc_index,
     acid_base,
-    walk_count,
     adjacency_matrix,
+    walk_count,
     wiener_index,
     zagreb_index,
 )

--- a/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
@@ -35,13 +35,14 @@ def calc(
     if n_frags != 1:
         return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32), FEATURE_NAMES
 
+    adj_matrix = adjacency_matrix.matrix
     attrs = MatrixAttributes(
-        adjacency_matrix.order(),  # base adjacency matrix A^1
+        adj_matrix,
         mol_regular,
         hermitian=adjacency_matrix.hermitian,
         n_frags=n_frags,
     )
-    return np.asarray(
+    values = np.asarray(
         [
             attrs.graph_energy,  # SpAbs_A
             attrs.leading_eigenvalue,  # SpMax_A
@@ -57,4 +58,5 @@ def calc(
             attrs.vr3,  # VR3_A
         ],
         dtype=np.float32,
-    ), FEATURE_NAMES
+    )
+    return values, FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
@@ -3,6 +3,7 @@ from rdkit.Chem import Mol
 
 from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
 from skfp.fingerprints._new_mordred.utils.matrix_attributes import MatrixAttributes
+
 """
 This code has been adapted from the BSD-licensed mordred-community library.
 https://github.com/JacksonBurns/mordred-community
@@ -26,30 +27,34 @@ FEATURE_NAMES = [
 ]
 
 
-def calc(mol_regular: Mol, n_frags: int, adjacency_matrix: AdjacencyMatrix) -> tuple[np.ndarray, list[str]]:
-    # if n_frags != 1:
-    #     return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32), FEATURE_NAMES
+def calc(
+    mol_regular: Mol, n_frags: int, adjacency_matrix: AdjacencyMatrix
+) -> tuple[np.ndarray, list[str]]:
+
+    # avoids unnecessary eigendecomposition for disconnected molecules
+    if n_frags != 1:
+        return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32), FEATURE_NAMES
 
     attrs = MatrixAttributes(
-        adjacency_matrix.order(),
+        adjacency_matrix.order(),  # base adjacency matrix A^1
         mol_regular,
         hermitian=adjacency_matrix.hermitian,
         n_frags=n_frags,
     )
     return np.asarray(
         [
-            attrs.graph_energy, # SpAbs_A
-            attrs.leading_eigenvalue, # SpMax_A
-            attrs.spectral_diameter, # SpDiam_A
-            attrs.sp_ad, # SpAD_A
-            attrs.sp_mad, # SpMAD_A
-            attrs.log_ee, # LogEE_A
-            attrs.ve1, # VE1_A
-            attrs.ve2, # VE2_A
-            attrs.ve3, # VE3_A
-            attrs.vr1, # VR1_A
-            attrs.vr2, # VR2_A
-            attrs.vr3, # VR3_A
+            attrs.graph_energy,  # SpAbs_A
+            attrs.leading_eigenvalue,  # SpMax_A
+            attrs.spectral_diameter,  # SpDiam_A
+            attrs.sp_ad,  # SpAD_A
+            attrs.sp_mad,  # SpMAD_A
+            attrs.log_ee,  # LogEE_A
+            attrs.ve1,  # VE1_A
+            attrs.ve2,  # VE2_A
+            attrs.ve3,  # VE3_A
+            attrs.vr1,  # VR1_A
+            attrs.vr2,  # VR2_A
+            attrs.vr3,  # VR3_A
         ],
         dtype=np.float32,
     ), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
@@ -30,7 +30,6 @@ FEATURE_NAMES = [
 def calc(
     mol_regular: Mol, n_frags: int, adjacency_matrix: AdjacencyMatrix
 ) -> tuple[np.ndarray, list[str]]:
-
     # avoids unnecessary eigendecomposition for disconnected molecules
     if n_frags != 1:
         return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/adjacency_matrix.py
@@ -1,0 +1,55 @@
+import numpy as np
+from rdkit.Chem import Mol
+
+from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
+from skfp.fingerprints._new_mordred.utils.matrix_attributes import MatrixAttributes
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = [
+    "SpAbs_A",
+    "SpMax_A",
+    "SpDiam_A",
+    "SpAD_A",
+    "SpMAD_A",
+    "LogEE_A",
+    "VE1_A",
+    "VE2_A",
+    "VE3_A",
+    "VR1_A",
+    "VR2_A",
+    "VR3_A",
+]
+
+
+def calc(mol_regular: Mol, n_frags: int, adjacency_matrix: AdjacencyMatrix) -> tuple[np.ndarray, list[str]]:
+    # if n_frags != 1:
+    #     return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32), FEATURE_NAMES
+
+    attrs = MatrixAttributes(
+        adjacency_matrix.order(),
+        mol_regular,
+        hermitian=adjacency_matrix.hermitian,
+        n_frags=n_frags,
+    )
+    return np.asarray(
+        [
+            attrs.graph_energy, # SpAbs_A
+            attrs.leading_eigenvalue, # SpMax_A
+            attrs.spectral_diameter, # SpDiam_A
+            attrs.sp_ad, # SpAD_A
+            attrs.sp_mad, # SpMAD_A
+            attrs.log_ee, # LogEE_A
+            attrs.ve1, # VE1_A
+            attrs.ve2, # VE2_A
+            attrs.ve3, # VE3_A
+            attrs.vr1, # VR1_A
+            attrs.vr2, # VR2_A
+            attrs.vr3, # VR3_A
+        ],
+        dtype=np.float32,
+    ), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
+++ b/skfp/fingerprints/_new_mordred/utils/graph_matrix.py
@@ -43,6 +43,10 @@ class AdjacencyMatrix:
         self._base = GetAdjacencyMatrix(mol, useBO=use_bond_orders)
         self._orders = [self._base]
 
+    @property
+    def matrix(self) -> np.ndarray:
+        return self._base
+
     def order(self, n: int = 1) -> np.ndarray:
         while len(self._orders) < n:
             self._orders.append(self._orders[-1].dot(self._base))

--- a/skfp/fingerprints/_new_mordred/utils/matrix_attributes.py
+++ b/skfp/fingerprints/_new_mordred/utils/matrix_attributes.py
@@ -152,4 +152,6 @@ class MatrixAttributes:
         """
         Logarithmic Randic-like eigenvector-based index.
         """
+        if self.vr1 <= 0:
+            return np.nan
         return np.log(0.1 * self._n_atoms * self.vr1)


### PR DESCRIPTION
This pull request introduces the new `adjacency_matrix` descriptor to the NewMordred fingerprint calculation.

New Features:

Added the `adjacency_matrix` descriptor, which computes 12 spectral features derived from the molecular adjacency matrix: graph energy (`SpAbs_A`), leading eigenvalue (`SpMax_A`), spectral diameter (`SpDiam_A`), spectral absolute and mean absolute deviation `(SpAD_A`, `SpMAD_A`), Estrada-like index (`LogEE_A`), eigenvector-based coefficients (`VE1_A`–`VE3_A`), and Randić-like eigenvector indices `(VR1_A`–`VR3_A`). These descriptors capture the electronic and topological structure of a molecule through the eigenspectrum of its graph representation.

## Checklist before requesting a review
- [ ] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
