### PR TITLE
Set default conf_id for SDF molecules

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -103,6 +103,7 @@ class MolFromSDFTransformer(BasePreprocessor):
         if not mols:
             warnings.warn("No molecules detected in provided SDF file")
 
+        self._set_default_conf_ids(mols)
         return mols
 
     def _transform_batch(self, X):
@@ -162,6 +163,15 @@ class MolFromSDFTransformer(BasePreprocessor):
             removeHs=self.remove_hydrogens,
         )
         return list(supplier)
+
+    def _set_default_conf_ids(self, mols: list[Mol]) -> None:
+        for mol in mols:
+            if (
+                mol is not None
+                and mol.GetNumConformers() > 0
+                and not mol.HasProp("conf_id")
+            ):
+                mol.SetIntProp("conf_id", 0)
 
 
 class MolToSDFTransformer(BasePreprocessor):

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -26,6 +26,20 @@ def test_mol_from_sdf(sdf_in_file_path):
 
     assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)
+    assert all(mol.HasProp("conf_id") for mol in mols)
+    assert all(mol.GetIntProp("conf_id") == 0 for mol in mols)
+
+
+def test_mol_from_sdf_text_sets_conf_id(sdf_in_file_path):
+    with open(sdf_in_file_path) as file:
+        sdf_text = file.read()
+
+    mol_from_sdf = MolFromSDFTransformer()
+    mols = mol_from_sdf.transform(sdf_text)
+
+    assert_equal(len(mols), 1)
+    assert all(mol.HasProp("conf_id") for mol in mols)
+    assert all(mol.GetIntProp("conf_id") == 0 for mol in mols)
 
 
 def test_mol_to_sdf(mols_list, sdf_out_file_path):


### PR DESCRIPTION
## Summary

- set `conf_id=0` on molecules loaded by `MolFromSDFTransformer` when an SDF record has a conformer but no existing `conf_id`
- cover both file-path and raw-SDF-text loading paths with regression assertions

Fixes #609.

## Validation

- `uv run pytest tests/preprocessing/input_output/sdf.py -q`
- `uv run ruff check skfp/preprocessing/input_output/sdf.py tests/preprocessing/input_output/sdf.py`
- `uv run ruff format --check skfp/preprocessing/input_output/sdf.py tests/preprocessing/input_output/sdf.py`
- `uv run mypy skfp/preprocessing/input_output/sdf.py`

## Note

PR #611 also touches the SDF transformer for path-like input support. This PR is scoped to the `conf_id` convention in #609 and may need a small rebase depending on merge order.
