### PR TITLE
fix: set conf_id for SDF-loaded molecules

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -103,10 +103,17 @@ class MolFromSDFTransformer(BasePreprocessor):
         if not mols:
             warnings.warn("No molecules detected in provided SDF file")
 
+        self._set_conf_ids(mols)
         return mols
 
     def _transform_batch(self, X):
         pass  # unused
+
+    @staticmethod
+    def _set_conf_ids(mols: list[Mol]) -> None:
+        for mol in mols:
+            if mol is not None and mol.GetNumConformers() > 0:
+                mol.SetIntProp("conf_id", mol.GetConformers()[0].GetId())
 
     def _read_sdf_file(self, filepath: str) -> list[Mol]:
         n_jobs = effective_n_jobs(self.n_jobs)

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -26,6 +26,7 @@ def test_mol_from_sdf(sdf_in_file_path):
 
     assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)
+    _assert_conf_ids_set(mols)
 
 
 def test_mol_to_sdf(mols_list, sdf_out_file_path):
@@ -52,6 +53,7 @@ def test_mol_from_sdf_parallel_from_file(sdf_in_file_path):
 
     assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)
+    _assert_conf_ids_set(mols)
 
 
 def test_mol_from_sdf_parallel_warns_for_raw_text(sdf_in_file_path):
@@ -67,6 +69,7 @@ def test_mol_from_sdf_parallel_warns_for_raw_text(sdf_in_file_path):
 
     assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)
+    _assert_conf_ids_set(mols)
 
 
 def test_mol_from_sdf_parallel_preserves_order(mols_list, tmp_path):
@@ -119,3 +122,10 @@ def _get_sdf_file_path(filename: str) -> str:
     if "input_output" in os.listdir():
         return os.path.join("input_output", "data", filename)
     raise FileNotFoundError(f"File {filename} not found")
+
+
+def _assert_conf_ids_set(mols: list[Mol]) -> None:
+    assert all(mol.HasProp("conf_id") for mol in mols)
+    assert all(
+        mol.GetIntProp("conf_id") == mol.GetConformers()[0].GetId() for mol in mols
+    )


### PR DESCRIPTION
## Changes

- Set `conf_id` on molecules returned by `MolFromSDFTransformer` when conformers are present.
- Use the first conformer's id for file, raw text, and parallel/fallback SDF read paths.
- Add regression assertions for file, raw text, and `n_jobs=2` SDF reads.

Fixes #609.

## Checklist before requesting a review

- [x] Public docs/docstrings unchanged; no public API change.
- [x] Tests added for the changed behavior.
- [x] Sphinx docs not needed for this bug fix.

## Testing

- `./.venv/bin/python -m pytest tests/preprocessing/input_output/sdf.py -q`
- `./.venv/bin/python -m ruff check skfp/preprocessing/input_output/sdf.py tests/preprocessing/input_output/sdf.py`
- `./.venv/bin/python -m compileall -q skfp/preprocessing/input_output/sdf.py tests/preprocessing/input_output/sdf.py`
