### PR TITLE
fix: support Path inputs for SDF reading

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -73,14 +73,14 @@ class MolFromSDFTransformer(BasePreprocessor):
         self.sanitize = sanitize
         self.remove_hydrogens = remove_hydrogens
 
-    def transform(self, X: str, copy: bool = False) -> list[Mol]:  # type: ignore[override]    # noqa: ARG002
+    def transform(self, X: str | os.PathLike[str], copy: bool = False) -> list[Mol]:  # type: ignore[override]    # noqa: ARG002
         """
         Create RDKit ``Mol`` objects from SDF file.
 
         Parameters
         ----------
-        X : str
-            Path to SDF file.
+        X : str or path-like
+            Path to SDF file, or raw SDF text.
 
         copy : bool, default=False
             Unused, kept for scikit-learn compatibility.
@@ -92,13 +92,20 @@ class MolFromSDFTransformer(BasePreprocessor):
         """
         self._validate_params()
 
-        if X.endswith(".sdf"):
-            if not os.path.exists(X):
-                raise FileNotFoundError(f"SDF file at path '{X}' not found")
-
-            mols = self._read_sdf_file(X)
+        if isinstance(X, os.PathLike):
+            sdf_input = os.fspath(X)
+            is_file_path = True
         else:
-            mols = self._read_sdf_text(X)
+            sdf_input = X
+            is_file_path = sdf_input.endswith(".sdf")
+
+        if is_file_path:
+            if not os.path.exists(sdf_input):
+                raise FileNotFoundError(f"SDF file at path '{sdf_input}' not found")
+
+            mols = self._read_sdf_file(sdf_input)
+        else:
+            mols = self._read_sdf_text(sdf_input)
 
         if not mols:
             warnings.warn("No molecules detected in provided SDF file")

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 from numpy.testing import assert_equal
@@ -23,6 +24,14 @@ def sdf_out_file_path():
 def test_mol_from_sdf(sdf_in_file_path):
     mol_from_sdf = MolFromSDFTransformer()
     mols = mol_from_sdf.transform(sdf_in_file_path)
+
+    assert_equal(len(mols), 1)
+    assert all(isinstance(x, Mol) for x in mols)
+
+
+def test_mol_from_sdf_path(sdf_in_file_path):
+    mol_from_sdf = MolFromSDFTransformer()
+    mols = mol_from_sdf.transform(Path(sdf_in_file_path))
 
     assert_equal(len(mols), 1)
     assert all(isinstance(x, Mol) for x in mols)


### PR DESCRIPTION
## Changes

- Accept `pathlib.Path` and other path-like objects in `MolFromSDFTransformer`.
- Convert path-like inputs with `os.fspath()` before passing file paths to RDKit.
- Add regression coverage for `Path` input.

Fixes #608.

## Checklist before requesting a review

- [x] Public docs/docstrings updated for accepted input types.
- [x] Tests added for the changed behavior.
- [x] Sphinx docs not needed for this small input-compatibility fix.

## Testing

- `./.venv/bin/python -m pytest tests/preprocessing/input_output/sdf.py -q`
- `./.venv/bin/python -m pytest tests/preprocessing/input_output -q`
- `./.venv/bin/python -m ruff check`
- `./.venv/bin/python -m mypy --package skfp --package tests`
- `./.venv/bin/python -m compileall -q skfp/preprocessing/input_output/sdf.py tests/preprocessing/input_output/sdf.py`
