### PR TITLE
fix: default missing 3D conf_id to zero

### DIFF
--- a/skfp/utils/validators.py
+++ b/skfp/utils/validators.py
@@ -60,15 +60,32 @@ def require_mols(X: Sequence[Any]) -> None:
 def require_mols_with_conf_ids(X: Sequence[Any]) -> Sequence[Mol]:
     """
     Check that all inputs are RDKit ``Mol`` objects with ``"conf_id"`` property
-    set, i.e. with conformers computed and properly identified. Raises TypeError
+    set or with conformers available for the default ``conf_id=0``. Raises TypeError
     otherwise.
     """
-    if not all(isinstance(x, (Mol, PropertyMol)) and x.HasProp("conf_id") for x in X):
+    if not all(isinstance(x, (Mol, PropertyMol)) for x in X):
         raise TypeError(
             "Passed data must be molecules (RDKit Mol objects) "
             "and each must have conf_id property set. "
             "You can use ConformerGenerator to add them."
         )
+
+    mols_without_conf_id = []
+    for mol in X:
+        if mol.HasProp("conf_id"):
+            continue
+        if mol.GetNumConformers() == 0:
+            raise TypeError(
+                "Passed data must be molecules (RDKit Mol objects) "
+                "and each must have conf_id property set, or have at least one "
+                "conformer to use the default conf_id=0. "
+                "You can use ConformerGenerator to add them."
+            )
+        mols_without_conf_id.append(mol)
+
+    for mol in mols_without_conf_id:
+        mol.SetIntProp("conf_id", 0)
+
     return X
 
 

--- a/tests/fingerprints/usr.py
+++ b/tests/fingerprints/usr.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
+from rdkit.Chem.PropertyMol import PropertyMol
 from rdkit.Chem.rdMolDescriptors import GetUSR
 
 from skfp.fingerprints import USRFingerprint
@@ -25,6 +26,20 @@ def test_usr_bit_fingerprint(mols_conformers_3_plus_atoms):
     assert_allclose(X_skfp, X_rdkit, atol=1e-3)
     assert_equal(X_skfp.shape, (len(mols_conformers_3_plus_atoms), 12))
     assert np.issubdtype(X_skfp.dtype, np.floating)
+
+
+def test_usr_bit_fingerprint_default_conf_id(mols_conformers_3_plus_atoms):
+    mols = [PropertyMol(mol) for mol in mols_conformers_3_plus_atoms]
+    for mol in mols:
+        mol.ClearProp("conf_id")
+
+    usr_fp = USRFingerprint()
+    X_skfp = usr_fp.transform(mols)
+
+    X_rdkit = np.array([GetUSR(mol, confId=0) for mol in mols])
+
+    assert_allclose(X_skfp, X_rdkit, atol=1e-3)
+    assert all(mol.GetIntProp("conf_id") == 0 for mol in mols)
 
 
 def test_usr_bit_fingerprint_transform_x_y(mols_conformers_3_plus_atoms):

--- a/tests/utils/validators.py
+++ b/tests/utils/validators.py
@@ -1,5 +1,6 @@
 import pytest
 from rdkit.Chem import MolFromSmiles
+from rdkit.Chem.PropertyMol import PropertyMol
 
 from skfp.fingerprints import AtomPairFingerprint
 from skfp.utils.validators import (
@@ -83,6 +84,27 @@ def test_require_mols_with_conf_ids(mols_conformers_list, mols_list):
     with pytest.raises(TypeError) as exc_info:
         require_mols_with_conf_ids(mols_conformers_list + mols_list)
     assert "each must have conf_id property set" in str(exc_info)
+
+
+def test_require_mols_with_conf_ids_default(mols_conformers_list):
+    mols = [PropertyMol(mol) for mol in mols_conformers_list[:2]]
+    for mol in mols:
+        mol.ClearProp("conf_id")
+
+    require_mols_with_conf_ids(mols)
+
+    assert all(mol.GetIntProp("conf_id") == 0 for mol in mols)
+
+
+def test_require_mols_with_conf_ids_default_no_partial_mutation(mols_conformers_list):
+    mol_with_conformer = PropertyMol(mols_conformers_list[0])
+    mol_with_conformer.ClearProp("conf_id")
+    mol_without_conformer = MolFromSmiles("O")
+
+    with pytest.raises(TypeError):
+        require_mols_with_conf_ids([mol_with_conformer, mol_without_conformer])
+
+    assert not mol_with_conformer.HasProp("conf_id")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- default missing 3D molecule `conf_id` values to `0` when conformers are present
- keep raising for non-molecule inputs or molecules without conformers
- add validator and USR regression coverage for externally supplied molecules without `conf_id`

## Testing

- `.venv/bin/pytest tests/utils/validators.py tests/fingerprints/usr.py`
- `.venv/bin/pytest tests/fingerprints/usr.py tests/fingerprints/usrcat.py tests/fingerprints/rdf.py tests/fingerprints/morse.py tests/fingerprints/whim.py tests/fingerprints/getaway.py tests/fingerprints/autocorr.py tests/fingerprints/atom_pair.py tests/fingerprints/pharmacophore.py`
- `.venv/bin/ruff check`
- `.venv/bin/mypy skfp tests`
- `.venv/bin/python -m compileall -q skfp tests`
- `git diff --check`
