### PR TITLE
Set conf_id property in MolFromSDFTransformer

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -22,6 +22,10 @@ class MolFromSDFTransformer(BasePreprocessor):
     molecules. For this reason ``.transform()`` either reads the SDF file directly
     from disk or takes a string input in that format.
 
+    Molecules with a conformation are returned as ``PropertyMol`` objects with
+    ``conf_id`` integer property set to the ID of their 0th conformer, the same
+    convention as :class:`~skfp.preprocessing.ConformerGenerator`.
+
     For details see RDKit documentation [1]_.
 
     Parameters
@@ -103,7 +107,16 @@ class MolFromSDFTransformer(BasePreprocessor):
         if not mols:
             warnings.warn("No molecules detected in provided SDF file")
 
-        return mols
+        return [self._set_conf_id(mol) for mol in mols]
+
+    @staticmethod
+    def _set_conf_id(mol: Mol | None) -> Mol | None:
+        if mol is None or not mol.GetNumConformers():
+            return mol
+
+        mol = PropertyMol(mol)
+        mol.SetIntProp("conf_id", mol.GetConformer(0).GetId())
+        return mol
 
     def _transform_batch(self, X):
         pass  # unused

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -28,6 +28,27 @@ def test_mol_from_sdf(sdf_in_file_path):
     assert all(isinstance(x, Mol) for x in mols)
 
 
+def test_mol_from_sdf_sets_conf_id(sdf_in_file_path):
+    mol_from_sdf = MolFromSDFTransformer()
+    mols = mol_from_sdf.transform(sdf_in_file_path)
+
+    for mol in mols:
+        assert mol.HasProp("conf_id")
+        assert_equal(mol.GetIntProp("conf_id"), mol.GetConformer(0).GetId())
+
+
+def test_mol_from_sdf_sets_conf_id_for_raw_text(sdf_in_file_path):
+    with open(sdf_in_file_path) as file:
+        sdf_text = file.read()
+
+    mol_from_sdf = MolFromSDFTransformer()
+    mols = mol_from_sdf.transform(sdf_text)
+
+    for mol in mols:
+        assert mol.HasProp("conf_id")
+        assert_equal(mol.GetIntProp("conf_id"), mol.GetConformer(0).GetId())
+
+
 def test_mol_to_sdf(mols_list, sdf_out_file_path):
     mol_to_sdf = MolToSDFTransformer(sdf_out_file_path)
     mol_to_sdf.transform(mols_list)


### PR DESCRIPTION
## Changes

Fixes #609.

`MolFromSDFTransformer` returned plain `Mol` objects without the `conf_id` integer property, while the convention elsewhere (`ConformerGenerator`, the 3D fingerprints, `MolToSDFTransformer`) is to read the conformation from `conf_id`. As a result, molecules loaded from SDF — which already carry a conformation — couldn't be passed to 3D fingerprints:

```python
mols = MolFromSDFTransformer().transform("mols.sdf")
RDFFingerprint().transform(mols)
# TypeError: Passed data must be molecules (RDKit Mol objects) and each must have conf_id property set.
```

Molecules with a conformation are now returned as `PropertyMol` with `conf_id` set to the ID of the 0th conformer, for all read paths (file, raw text, multithreaded). Molecules that failed to parse (`None`) or have no conformers are returned unchanged.

Added tests for the file and raw-text paths; both fail before the change and pass after. Full test suite (`pytest tests --ignore=tests/datasets`, 1546 passed) and ruff are green.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`) — no doc source changes; the class docs come from the updated docstring