### PR TITLE
Support pathlib.Path in MolFromSDFTransformer

### DIFF
--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -2,6 +2,7 @@ import os.path
 import warnings
 from collections.abc import Sequence
 from numbers import Integral
+from pathlib import Path
 
 from joblib import effective_n_jobs
 from rdkit.Chem import Mol, SDMolSupplier, SDWriter
@@ -77,14 +78,14 @@ class MolFromSDFTransformer(BasePreprocessor):
         self.sanitize = sanitize
         self.remove_hydrogens = remove_hydrogens
 
-    def transform(self, X: str, copy: bool = False) -> list[Mol]:  # type: ignore[override]    # noqa: ARG002
+    def transform(self, X: str | Path, copy: bool = False) -> list[Mol]:  # type: ignore[override]    # noqa: ARG002
         """
         Create RDKit ``Mol`` objects from SDF file.
 
         Parameters
         ----------
-        X : str
-            Path to SDF file.
+        X : str or Path
+            Path to SDF file (``str`` or ``pathlib.Path``), or raw SDF text.
 
         copy : bool, default=False
             Unused, kept for scikit-learn compatibility.
@@ -95,6 +96,9 @@ class MolFromSDFTransformer(BasePreprocessor):
             List with RDKit ``Mol`` objects.
         """
         self._validate_params()
+
+        # accept pathlib.Path as well as str; raw SDF text (str) passes through unchanged
+        X = os.fspath(X)
 
         if X.endswith(".sdf"):
             if not os.path.exists(X):

--- a/tests/preprocessing/input_output/sdf.py
+++ b/tests/preprocessing/input_output/sdf.py
@@ -28,6 +28,17 @@ def test_mol_from_sdf(sdf_in_file_path):
     assert all(isinstance(x, Mol) for x in mols)
 
 
+def test_mol_from_sdf_accepts_path_object(sdf_in_file_path):
+    from pathlib import Path
+
+    mol_from_sdf = MolFromSDFTransformer()
+    mols_from_str = mol_from_sdf.transform(sdf_in_file_path)
+    mols_from_path = mol_from_sdf.transform(Path(sdf_in_file_path))
+
+    assert_equal(len(mols_from_path), len(mols_from_str))
+    assert all(isinstance(x, Mol) for x in mols_from_path)
+
+
 def test_mol_from_sdf_sets_conf_id(sdf_in_file_path):
     mol_from_sdf = MolFromSDFTransformer()
     mols = mol_from_sdf.transform(sdf_in_file_path)


### PR DESCRIPTION
Closes #608.

`MolFromSDFTransformer.transform` only accepted `str`. A `pathlib.Path` broke at `X.endswith(".sdf")` (Path has no `.endswith`).

Fix: normalize the input with `os.fspath(X)` at the start of `transform`, so a `Path` is accepted while `str` paths and raw SDF text pass through unchanged. Type hint and docstring widened to `str | Path`.

Scope: this addresses the reader named in the issue. `MolToSDFTransformer` takes its output path as a constructor param constrained to `[str]`; happy to extend that to `PathLike` in a follow-up if you want the writer to accept `Path` too.

Verified: `pytest tests/preprocessing/input_output/sdf.py` → 11 passed (added `test_mol_from_sdf_accepts_path_object`); `ruff check` + `ruff format` clean.