### PR TITLE
Add mordred aromatic count descriptors

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -5,6 +5,7 @@ from skfp.fingerprints._new_mordred.descriptors import (
     abc_index,
     acid_base,
     adjacency_matrix,
+    aromatic,
     atom_count,
     autocorrelation,
     barysz_matrix,
@@ -102,6 +103,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
             n_frags,
         ),
         barysz_matrix.calc(mol_regular, n_frags),
+        aromatic.calc(mol_regular),
     ]
 
     for values, feature_names in descriptors_2d:

--- a/skfp/fingerprints/_new_mordred/descriptors/aromatic.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/aromatic.py
@@ -1,0 +1,26 @@
+import numpy as np
+from rdkit.Chem import Mol
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = ["nAromAtom", "nAromBond"]
+
+
+def calc(mol: Mol) -> tuple[np.ndarray, list[str]]:
+    """
+    Compute the Mordred aromatic count descriptors.
+
+    `nAromAtom` is the number of aromatic atoms and `nAromBond` is the number of
+    aromatic bonds, both taken directly from RDKit's perceived aromaticity flags.
+    """
+    values = [
+        sum(atom.GetIsAromatic() for atom in mol.GetAtoms()),
+        sum(bond.GetIsAromatic() for bond in mol.GetBonds()),
+    ]
+
+    return np.asarray(values, dtype=np.float32), FEATURE_NAMES

--- a/tests/fingerprints/_new_mordred/aromatic.py
+++ b/tests/fingerprints/_new_mordred/aromatic.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+from numpy.testing import assert_allclose
+
+from skfp.fingerprints._new_mordred.descriptors.aromatic import FEATURE_NAMES, calc
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+Reference values come from ChemAxon cxcalc (as bundled with mordred-community)
+and are stored at ./references/aromatic.json as expected[molecule][descriptor].
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+with open(Path(__file__).parent / "references" / "aromatic.json") as f:
+    _REFERENCE = json.load(f)
+
+
+@pytest.mark.parametrize("molecule", list(_REFERENCE))
+def test_aromatic_reference_values(molecule, mordred_test_mols):
+    mol = mordred_test_mols[molecule]
+
+    values, feature_names = calc(mol)
+
+    assert feature_names == FEATURE_NAMES
+    expected = [_REFERENCE[molecule][name] for name in feature_names]
+    assert_allclose(values, expected)

--- a/tests/fingerprints/_new_mordred/references/aromatic.json
+++ b/tests/fingerprints/_new_mordred/references/aromatic.json
@@ -1,0 +1,15 @@
+{
+  "Hexane": {"nAromAtom": 0, "nAromBond": 0},
+  "Benzene": {"nAromAtom": 6, "nAromBond": 6},
+  "Caffeine": {"nAromAtom": 9, "nAromBond": 10},
+  "Cyanidin": {"nAromAtom": 16, "nAromBond": 17},
+  "Lycopene": {"nAromAtom": 0, "nAromBond": 0},
+  "Epicatechin": {"nAromAtom": 12, "nAromBond": 12},
+  "Limonene": {"nAromAtom": 0, "nAromBond": 0},
+  "Allicin": {"nAromAtom": 0, "nAromBond": 0},
+  "Glutathione": {"nAromAtom": 0, "nAromBond": 0},
+  "Digoxin": {"nAromAtom": 0, "nAromBond": 0},
+  "Capsaicin": {"nAromAtom": 6, "nAromBond": 6},
+  "EllagicAcid": {"nAromAtom": 16, "nAromBond": 19},
+  "Astaxanthin": {"nAromAtom": 0, "nAromBond": 0}
+}


### PR DESCRIPTION
## Changes

* Added new `aromatic` descriptor module (`skfp/fingerprints/_new_mordred/descriptors/aromatic.py`) that computes the number of aromatic atoms and bonds using RDKit's aromaticity flags.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
