### PR TITLE
Fix datasets tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,15 @@ jobs:
       - name: Run tests with pytest
         run: uv run make test
         env:
+          # pin the exact PR base/head so dataset tests only run when this PR
+          # actually changes datasets (see DATASETS_CHANGED in the Makefile)
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}  # faster datasets download
 
       - name: Run docstring tests
-        run: uv run make -C docs doctest
+        run: uv run make run-doctest
         env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}  # faster datasets download

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup docs doctest test test-coverage help
+.PHONY: setup docs doctest run-doctest test test-coverage help
 .DEFAULT_GOAL := help
 
 setup: ## Install development dependencies
@@ -15,16 +15,20 @@ setup: ## Install development dependencies
 docs: ## Re-generate documentation
 	uv run $(MAKE) -C docs html
 
-doctest: docs ## Run documentation tests
-	uv run $(MAKE) -C docs doctest
-
-# detect if datasets directory changed for tests
+# detect if datasets changed for tests
+# on CI, PR_BASE_SHA / PR_HEAD_SHA pin the exact PR base and head, which is
+# robust against the auto-generated merge commit and a moving origin/master
+# locally compare current branch against origin/master
 define DATASETS_CHANGED
 { \
-	git diff --name-only origin/master...HEAD ;\
+	if [ -n "$$PR_BASE_SHA" ] && [ -n "$$PR_HEAD_SHA" ]; then \
+		git diff --name-only "$$PR_BASE_SHA...$$PR_HEAD_SHA" ;\
+	else \
+		git diff --name-only origin/master...HEAD ;\
+	fi ;\
 	git diff --name-only --cached ;\
 	git diff --name-only ;\
-} | grep -q '^skfp/datasets/'
+} | grep -qE '^(skfp|tests)/datasets/'
 endef
 
 test: ## Run tests
@@ -50,6 +54,17 @@ test-coverage: ## Run tests and calculate test coverage
 	-mkdir .tmp_coverage_files
 	uv run pytest --cov=skfp tests
 	-rm -rf .tmp_coverage_files
+
+doctest: docs run-doctest ## Build docs and run documentation tests
+
+run-doctest: ## Run documentation tests
+	@if $(DATASETS_CHANGED); then \
+	  echo "Datasets changed, running all doctests" ;\
+	  uv run $(MAKE) -C docs doctest ;\
+	else \
+	  echo "Skipping datasets doctests" ;\
+	  SKFP_SKIP_DATASET_DOCTESTS=1 uv run $(MAKE) -C docs doctest ;\
+	fi
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,15 @@ exclude_patterns = [
     "Thumbs.db",
 ]
 
+# dataset doctests are slow, so we skip them if they did not change on Git
+if os.environ.get("SKFP_SKIP_DATASET_DOCTESTS"):
+    exclude_patterns += [
+        "modules/datasets.rst",
+        "modules/datasets/**",
+    ]
+    # silence the toctree reference to the now-excluded datasets page
+    suppress_warnings = ["toc.excluded"]
+
 intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
 }

--- a/tests/datasets/asap.py
+++ b/tests/datasets/asap.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -24,9 +25,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_asap_benchmark():
     benchmark_full = load_asap_benchmark(as_frames=True)
@@ -39,9 +40,9 @@ def test_load_asap_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_asap_benchmark_subset():
     dataset_names = ["LogD", "KSOL", "MLM"]
@@ -51,9 +52,9 @@ def test_load_asap_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_asap_benchmark_wrong_subset():
     dataset_names = ["LogD", "Nonexistent"]
@@ -64,9 +65,9 @@ def test_load_asap_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", ASAP_DATASET_NAMES)
 def test_load_asap_splits(dataset_name):
@@ -83,9 +84,9 @@ def test_load_asap_splits(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", ASAP_DATASET_NAMES)
 def test_load_asap_splits_as_dict(dataset_name):
@@ -98,9 +99,9 @@ def test_load_asap_splits_as_dict(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
@@ -121,9 +122,9 @@ def test_load_asap_splits_lengths(dataset_name, dataset_length):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_asap_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
@@ -135,9 +136,9 @@ def test_load_asap_splits_nonexistent_dataset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
@@ -179,9 +180,9 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "subset_name, expected_num_datasets",

--- a/tests/datasets/biogen_adme.py
+++ b/tests/datasets/biogen_adme.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 
 from skfp.datasets.biogen_adme import (
@@ -21,9 +22,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_biogen_adme_benchmark():
     benchmark_full = load_biogen_adme_benchmark(as_frames=True)
@@ -36,9 +37,9 @@ def test_load_biogen_adme_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_biogen_adme_benchmark_subset():
     dataset_names = ["HLM CLint", "Solubility", "RLM CLint"]
@@ -48,9 +49,9 @@ def test_load_biogen_adme_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_biogen_adme_benchmark_wrong_subset():
     dataset_names = ["HLM CLint", "Nonexistent"]
@@ -61,9 +62,9 @@ def test_load_biogen_adme_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
@@ -92,9 +93,9 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "subset_name, expected_num_datasets",

--- a/tests/datasets/expansionrx.py
+++ b/tests/datasets/expansionrx.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -27,9 +28,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_expansionrx_benchmark():
     benchmark_full = load_expansionrx_benchmark(as_frames=True)
@@ -42,9 +43,9 @@ def test_load_expansionrx_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_expansionrx_benchmark_subset():
     dataset_names = ["LogD", "KSOL", "MPPB"]
@@ -54,9 +55,9 @@ def test_load_expansionrx_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_expansionrx_benchmark_wrong_subset():
     dataset_names = ["LogD", "Nonexistent"]
@@ -67,9 +68,9 @@ def test_load_expansionrx_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", EXPANSIONRX_DATASET_NAMES)
 def test_load_expansionrx_splits(dataset_name):
@@ -86,9 +87,9 @@ def test_load_expansionrx_splits(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", EXPANSIONRX_DATASET_NAMES)
 def test_load_expansionrx_splits_as_dict(dataset_name):
@@ -101,9 +102,9 @@ def test_load_expansionrx_splits_as_dict(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
@@ -127,9 +128,9 @@ def test_load_expansionrx_splits_lengths(dataset_name, dataset_length):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_expansionrx_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
@@ -141,9 +142,9 @@ def test_load_expansionrx_splits_nonexistent_dataset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
@@ -188,9 +189,9 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "subset_name, expected_num_datasets",

--- a/tests/datasets/lrgb.py
+++ b/tests/datasets/lrgb.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 
 from skfp.datasets.lrgb import (
@@ -16,9 +17,9 @@ def get_dataset_names() -> list[str]:
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_lrgb_benchmark():
     dataset_names = get_dataset_names()
@@ -32,9 +33,9 @@ def test_load_lrgb_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", get_dataset_names())
 def test_load_lrgb_splits(dataset_name):
@@ -56,9 +57,9 @@ def test_load_lrgb_splits(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", get_dataset_names())
 def test_load_lrgb_splits_as_dict(dataset_name):
@@ -72,9 +73,9 @@ def test_load_lrgb_splits_as_dict(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, valid_sequences_only, dataset_length",
@@ -92,9 +93,9 @@ def test_load_lrgb_splits_lengths(dataset_name, valid_sequences_only, dataset_le
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",

--- a/tests/datasets/moleculeace.py
+++ b/tests/datasets/moleculeace.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from sklearn.utils._param_validation import InvalidParameterError
 
 from skfp.datasets.moleculeace import (
@@ -41,9 +42,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculeace_benchmark():
     benchmark_full = load_moleculeace_benchmark(as_frames=True)
@@ -56,9 +57,9 @@ def test_load_moleculeace_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculeace_benchmark_subset():
     dataset_names = ["chembl4005_ki", "chembl204_ki", "chembl235_ec50"]
@@ -68,9 +69,9 @@ def test_load_moleculeace_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculeace_benchmark_wrong_subset():
     dataset_names = ["chembl4005_ki", "Nonexistent"]
@@ -81,9 +82,9 @@ def test_load_moleculeace_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("split_type", ["random", "activity_cliff"])
 @pytest.mark.parametrize("dataset_name", MOLECULEACE_DATASET_NAMES)
@@ -101,9 +102,9 @@ def test_load_moleculeace_splits(dataset_name, split_type):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("split_type", ["random", "activity_cliff"])
 @pytest.mark.parametrize("dataset_name", MOLECULEACE_DATASET_NAMES)
@@ -117,9 +118,9 @@ def test_load_moleculeace_splits_as_dict(dataset_name, split_type):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
@@ -163,9 +164,9 @@ def test_load_moleculeace_splits_lengths(dataset_name, dataset_length):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", MOLECULEACE_DATASET_NAMES)
 def test_load_moleculeace_splits_activity_cliffs(dataset_name):
@@ -181,9 +182,9 @@ def test_load_moleculeace_splits_activity_cliffs(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("split_type", ["random", "activity_cliff"])
 def test_load_moleculeace_splits_nonexistent_dataset(split_type):
@@ -196,9 +197,9 @@ def test_load_moleculeace_splits_nonexistent_dataset(split_type):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculeace_splits_nonexistent_splits():
     with pytest.raises(InvalidParameterError) as error:
@@ -210,9 +211,9 @@ def test_load_moleculeace_splits_nonexistent_splits():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",

--- a/tests/datasets/moleculenet.py
+++ b/tests/datasets/moleculenet.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -27,9 +28,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculenet_benchmark():
     benchmark_full = load_moleculenet_benchmark(as_frames=True)
@@ -42,9 +43,9 @@ def test_load_moleculenet_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculenet_benchmark_subset():
     dataset_names = ["ESOL", "SIDER", "BACE"]
@@ -54,9 +55,9 @@ def test_load_moleculenet_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_moleculenet_benchmark_wrong_subset():
     dataset_names = ["ESOL", "Nonexistent"]
@@ -67,9 +68,9 @@ def test_load_moleculenet_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", MOLECULENET_DATASET_NAMES)
 def test_load_ogb_splits(dataset_name):
@@ -91,9 +92,9 @@ def test_load_ogb_splits(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", MOLECULENET_DATASET_NAMES)
 def test_load_ogb_splits_as_dict(dataset_name):
@@ -107,9 +108,9 @@ def test_load_ogb_splits_as_dict(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
@@ -135,9 +136,9 @@ def test_load_ogb_splits_lengths(dataset_name, dataset_length):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_ogb_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
@@ -149,9 +150,9 @@ def test_load_ogb_splits_nonexistent_dataset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
@@ -185,9 +186,9 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "subset_name, expected_num_datasets",

--- a/tests/datasets/tdc.py
+++ b/tests/datasets/tdc.py
@@ -1,4 +1,5 @@
 import pytest
+from huggingface_hub.errors import LocalEntryNotFoundError
 from numpy.testing import assert_equal
 from sklearn.utils._param_validation import InvalidParameterError
 
@@ -53,9 +54,9 @@ from tests.datasets.test_utils import run_basic_dataset_checks
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_tdc_benchmark():
     benchmark_full = load_tdc_benchmark(as_frames=True)
@@ -68,9 +69,9 @@ def test_load_tdc_benchmark():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_tdc_benchmark_subset():
     dataset_names = ["pampa_approved_drugs", "sarscov2_3clpro_diamond", "ames"]
@@ -80,9 +81,9 @@ def test_load_tdc_benchmark_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_tdc_benchmark_wrong_subset():
     dataset_names = ["pampa_approved_drugs", "Nonexistent"]
@@ -93,9 +94,9 @@ def test_load_tdc_benchmark_wrong_subset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", TDC_DATASET_NAMES)
 def test_load_tdc_splits(dataset_name):
@@ -117,9 +118,9 @@ def test_load_tdc_splits(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize("dataset_name", TDC_DATASET_NAMES)
 def test_load_ogb_splits_as_dict(dataset_name):
@@ -133,9 +134,9 @@ def test_load_ogb_splits_as_dict(dataset_name):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, dataset_length",
@@ -184,9 +185,9 @@ def test_load_tdc_splits_lengths(dataset_name, dataset_length):
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 def test_load_tdc_splits_nonexistent_dataset():
     with pytest.raises(InvalidParameterError) as error:
@@ -198,9 +199,9 @@ def test_load_tdc_splits_nonexistent_dataset():
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "dataset_name, load_func, expected_length, num_tasks, task_type",
@@ -317,9 +318,9 @@ def test_load_dataset(dataset_name, load_func, expected_length, num_tasks, task_
 
 
 @pytest.mark.flaky(
-    reruns=100,
+    reruns=10,
     reruns_delay=5,
-    only_rerun=["LocalEntryNotFoundError", "FileNotFoundError"],
+    only_rerun=[LocalEntryNotFoundError, FileNotFoundError],
 )
 @pytest.mark.parametrize(
     "subset_name, expected_num_datasets",


### PR DESCRIPTION
## Changes

Improves detection of "datasets changed" to avoid running slow tests on CI. Also applies to doctests now. Reduced reruns, I analyzed the CI runs and flaky tests always succeed or fail totally during the first 10 runs.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
