### PR TITLE
More robust conformer ID handling

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -18,8 +18,9 @@ Validators:
 
     ensure_mols
     ensure_smiles
+    get_conf_id
     require_mols
-    require_mols_with_conf_ids
+    require_mols_with_conformations
     require_strings
 
 Utilities:

--- a/skfp/fingerprints/atom_pair.py
+++ b/skfp/fingerprints/atom_pair.py
@@ -8,7 +8,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import Interval, InvalidParameterError
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import ensure_mols, require_mols_with_conf_ids
+from skfp.utils import ensure_mols, get_conf_id, require_mols_with_conformations
 
 
 class AtomPairFingerprint(BaseFingerprintTransformer):
@@ -103,8 +103,9 @@ class AtomPairFingerprint(BaseFingerprintTransformer):
 
     requires_conformers : bool
         Whether the fingerprint is 3D-based and requires molecules with conformers as
-        inputs, with ``conf_id`` integer property set. This depends on the ``use_3D``
-        parameter, and has the same value.
+        inputs. This depends on the ``use_3D`` parameter, and has the same value. If the
+        ``conf_id`` property is set, it will be used to determine the conformation.
+        You can use :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -231,8 +232,8 @@ class AtomPairFingerprint(BaseFingerprintTransformer):
         )
 
         if self.use_3D:
-            X = require_mols_with_conf_ids(X)
-            conf_ids = [mol.GetIntProp("conf_id") for mol in X]
+            X = require_mols_with_conformations(X)
+            conf_ids = [get_conf_id(mol) for mol in X]
         else:
             X = ensure_mols(X)
             conf_ids = [-1 for _ in X]

--- a/skfp/fingerprints/autocorr.py
+++ b/skfp/fingerprints/autocorr.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Mol
 from scipy.sparse import csr_array
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import ensure_mols, require_mols_with_conf_ids
+from skfp.utils import ensure_mols, get_conf_id, require_mols_with_conformations
 
 
 class AutocorrFingerprint(BaseFingerprintTransformer):
@@ -68,8 +68,9 @@ class AutocorrFingerprint(BaseFingerprintTransformer):
 
     requires_conformers : bool
         Whether the fingerprint is 3D-based and requires molecules with conformers as
-        inputs, with ``conf_id`` integer property set. This depends on the ``use_3D``
-        parameter, and has the same value.
+        inputs. This depends on the ``use_3D`` parameter, and has the same value. If the
+        ``conf_id`` property is set, it will be used to determine the conformation.
+        You can use :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     References
     ----------
@@ -213,7 +214,7 @@ class AutocorrFingerprint(BaseFingerprintTransformer):
             X = ensure_mols(X)
             X = [CalcAUTOCORR2D(mol) for mol in X]
         else:
-            X = require_mols_with_conf_ids(X)
-            X = [CalcAUTOCORR3D(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+            X = require_mols_with_conformations(X)
+            X = [CalcAUTOCORR3D(mol, confId=get_conf_id(mol)) for mol in X]
 
         return np.array(X)

--- a/skfp/fingerprints/e3fp_fp.py
+++ b/skfp/fingerprints/e3fp_fp.py
@@ -10,7 +10,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import Interval, InvalidParameterError
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import require_mols_with_conformations
 
 """
 Note: this file cannot have the "e3fp.py" name due to conflict with E3FP library.
@@ -92,8 +92,10 @@ class E3FPFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints. Equal to ``fp_size``.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -194,7 +196,7 @@ class E3FPFingerprint(BaseFingerprintTransformer):
         return super().transform(X, copy)
 
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
-        X = require_mols_with_conf_ids(X)
+        X = require_mols_with_conformations(X)
         X = [self._calculate_single_mol_fingerprint(mol) for mol in X]
         return scipy.sparse.vstack(X) if self.sparse else np.array(X)
 

--- a/skfp/fingerprints/electroshape.py
+++ b/skfp/fingerprints/electroshape.py
@@ -11,7 +11,7 @@ from sklearn.utils._param_validation import Interval, StrOptions
 
 from skfp.bases import BaseFingerprintTransformer
 from skfp.descriptors.charge import atomic_partial_charges
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class ElectroShapeFingerprint(BaseFingerprintTransformer):
@@ -85,8 +85,10 @@ class ElectroShapeFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -248,7 +250,7 @@ class ElectroShapeFingerprint(BaseFingerprintTransformer):
         return X, y
 
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
-        mols = require_mols_with_conf_ids(X)
+        mols = require_mols_with_conformations(X)
 
         if self.errors == "raise":
             fps = [self._get_fp(mol) for mol in mols]
@@ -264,7 +266,7 @@ class ElectroShapeFingerprint(BaseFingerprintTransformer):
         return np.array(fps)
 
     def _get_fp(self, mol: Mol) -> np.ndarray:
-        conf_id = mol.GetIntProp("conf_id")
+        conf_id = get_conf_id(mol)
         coords = mol.GetConformer(conf_id).GetPositions()
         charges = atomic_partial_charges(
             mol, self.partial_charge_model, self.charge_errors

--- a/skfp/fingerprints/getaway.py
+++ b/skfp/fingerprints/getaway.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import Interval
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class GETAWAYFingerprint(BaseFingerprintTransformer):
@@ -71,8 +71,10 @@ class GETAWAYFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     References
     ----------
@@ -241,8 +243,8 @@ class GETAWAYFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import CalcGETAWAY
 
-        X = require_mols_with_conf_ids(X)
-        X = [CalcGETAWAY(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+        X = require_mols_with_conformations(X)
+        X = [CalcGETAWAY(mol, confId=get_conf_id(mol)) for mol in X]
         if self.clip_val is not None:
             X = np.clip(X, -self.clip_val, self.clip_val)
 

--- a/skfp/fingerprints/morse.py
+++ b/skfp/fingerprints/morse.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Mol
 from scipy.sparse import csr_array
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class MORSEFingerprint(BaseFingerprintTransformer):
@@ -59,8 +59,10 @@ class MORSEFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -195,6 +197,6 @@ class MORSEFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import CalcMORSE
 
-        X = require_mols_with_conf_ids(X)
-        X = [CalcMORSE(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+        X = require_mols_with_conformations(X)
+        X = [CalcMORSE(mol, confId=get_conf_id(mol)) for mol in X]
         return csr_array(X) if self.sparse else np.array(X)

--- a/skfp/fingerprints/pharmacophore.py
+++ b/skfp/fingerprints/pharmacophore.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import Interval, InvalidParameterError, StrOptions
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import ensure_mols, require_mols_with_conf_ids
+from skfp.utils import ensure_mols, get_conf_id, require_mols_with_conformations
 
 
 class PharmacophoreFingerprint(BaseFingerprintTransformer):
@@ -94,8 +94,9 @@ class PharmacophoreFingerprint(BaseFingerprintTransformer):
 
     requires_conformers : bool
         Whether the fingerprint is 3D-based and requires molecules with conformers as
-        inputs, with ``conf_id`` integer property set. This depends on the ``use_3D``
-        parameter, and has the same value.
+        inputs. This depends on the ``use_3D`` parameter, and has the same value. If the
+        ``conf_id`` property is set, it will be used to determine the conformation.
+        You can use :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     References
     ----------
@@ -231,12 +232,12 @@ class PharmacophoreFingerprint(BaseFingerprintTransformer):
             X = ensure_mols(X)
             X = [Gen2DFingerprint(mol, factory) for mol in X]
         else:
-            X = require_mols_with_conf_ids(X)
+            X = require_mols_with_conformations(X)
             X = [
                 Gen2DFingerprint(
                     mol,
                     factory,
-                    dMat=Get3DDistanceMatrix(mol, confId=mol.GetIntProp("conf_id")),
+                    dMat=Get3DDistanceMatrix(mol, confId=get_conf_id(mol)),
                 )
                 for mol in X
             ]

--- a/skfp/fingerprints/rdf.py
+++ b/skfp/fingerprints/rdf.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Mol
 from scipy.sparse import csr_array
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class RDFFingerprint(BaseFingerprintTransformer):
@@ -64,8 +64,10 @@ class RDFFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -187,6 +189,6 @@ class RDFFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import CalcRDF
 
-        X = require_mols_with_conf_ids(X)
-        X = [CalcRDF(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+        X = require_mols_with_conformations(X)
+        X = [CalcRDF(mol, confId=get_conf_id(mol)) for mol in X]
         return csr_array(X) if self.sparse else np.array(X)

--- a/skfp/fingerprints/usr.py
+++ b/skfp/fingerprints/usr.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import StrOptions
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class USRFingerprint(BaseFingerprintTransformer):
@@ -63,8 +63,10 @@ class USRFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -223,15 +225,15 @@ class USRFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import GetUSR
 
-        X = require_mols_with_conf_ids(X)
+        X = require_mols_with_conformations(X)
 
         if self.errors == "raise":
-            fps = [GetUSR(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+            fps = [GetUSR(mol, confId=get_conf_id(mol)) for mol in X]
         else:  # self.errors in {"NaN", "ignore"}
             fps = []
             for mol in X:
                 try:
-                    fp = GetUSR(mol, confId=mol.GetIntProp("conf_id"))
+                    fp = GetUSR(mol, confId=get_conf_id(mol))
                 except ValueError:
                     fp = np.full(self.n_features_out, np.nan)
                 fps.append(fp)

--- a/skfp/fingerprints/usrcat.py
+++ b/skfp/fingerprints/usrcat.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import StrOptions
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class USRCATFingerprint(BaseFingerprintTransformer):
@@ -66,8 +66,10 @@ class USRCATFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     See Also
     --------
@@ -233,15 +235,15 @@ class USRCATFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import GetUSRCAT
 
-        X = require_mols_with_conf_ids(X)
+        X = require_mols_with_conformations(X)
 
         if self.errors == "raise":
-            fps = [GetUSRCAT(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+            fps = [GetUSRCAT(mol, confId=get_conf_id(mol)) for mol in X]
         else:  # self.errors in {"NaN", "ignore"}
             fps = []
             for mol in X:
                 try:
-                    fp = GetUSRCAT(mol, confId=mol.GetIntProp("conf_id"))
+                    fp = GetUSRCAT(mol, confId=get_conf_id(mol))
                 except ValueError:
                     fp = np.full(self.n_features_out, np.nan)
                 fps.append(fp)

--- a/skfp/fingerprints/whim.py
+++ b/skfp/fingerprints/whim.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_array
 from sklearn.utils._param_validation import Interval
 
 from skfp.bases import BaseFingerprintTransformer
-from skfp.utils import require_mols_with_conf_ids
+from skfp.utils import get_conf_id, require_mols_with_conformations
 
 
 class WHIMFingerprint(BaseFingerprintTransformer):
@@ -68,8 +68,10 @@ class WHIMFingerprint(BaseFingerprintTransformer):
         Number of output features, size of fingerprints.
 
     requires_conformers : bool = True
-        Value is always True, as this fingerprint is 3D based. It always requires
-        molecules with conformers as inputs, with ``conf_id`` integer property set.
+        Value is always True, as this fingerprint is 3D-based. It always requires
+        molecules with conformers as input. If the ``conf_id`` property is set, it
+        will be used to determine the conformation. You can use
+        :class:`~skfp.preprocessing.ConformerGenerator` to generate them.
 
     References
     ----------
@@ -238,8 +240,8 @@ class WHIMFingerprint(BaseFingerprintTransformer):
     def _calculate_fingerprint(self, X: Sequence[Mol]) -> np.ndarray | csr_array:
         from rdkit.Chem.rdMolDescriptors import CalcWHIM
 
-        X = require_mols_with_conf_ids(X)
-        X = [CalcWHIM(mol, confId=mol.GetIntProp("conf_id")) for mol in X]
+        X = require_mols_with_conformations(X)
+        X = [CalcWHIM(mol, confId=get_conf_id(mol)) for mol in X]
         if self.clip_val is not None:
             X = np.clip(X, -self.clip_val, self.clip_val)
 

--- a/skfp/preprocessing/input_output/sdf.py
+++ b/skfp/preprocessing/input_output/sdf.py
@@ -119,7 +119,7 @@ class MolFromSDFTransformer(BasePreprocessor):
             return mol
 
         mol = PropertyMol(mol)
-        mol.SetIntProp("conf_id", mol.GetConformer(0).GetId())
+        mol.SetIntProp("conf_id", mol.GetConformer().GetId())
         return mol
 
     def _transform_batch(self, X):

--- a/skfp/utils/__init__.py
+++ b/skfp/utils/__init__.py
@@ -4,7 +4,8 @@ from .rdkit_logging import no_rdkit_logs
 from .validators import (
     ensure_mols,
     ensure_smiles,
+    get_conf_id,
     require_mols,
-    require_mols_with_conf_ids,
+    require_mols_with_conformations,
     require_strings,
 )

--- a/skfp/utils/validators.py
+++ b/skfp/utils/validators.py
@@ -57,19 +57,34 @@ def require_mols(X: Sequence[Any]) -> None:
             )
 
 
-def require_mols_with_conf_ids(X: Sequence[Any]) -> Sequence[Mol]:
+def require_mols_with_conformations(X: Sequence[Any]) -> Sequence[Mol]:
     """
-    Check that all inputs are RDKit ``Mol`` objects with ``"conf_id"`` property
-    set, i.e. with conformers computed and properly identified. Raises TypeError
-    otherwise.
+    Check that all inputs are RDKit ``Mol`` objects with at least one conformation,
+    i.e. with 3D coordinates computed. Raises TypeError otherwise.
     """
-    if not all(isinstance(x, (Mol, PropertyMol)) and x.HasProp("conf_id") for x in X):
+    if not all(
+        isinstance(x, (Mol, PropertyMol)) and x.GetNumConformers() >= 1 for x in X
+    ):
         raise TypeError(
             "Passed data must be molecules (RDKit Mol objects) "
-            "and each must have conf_id property set. "
+            "and each must have at least one conformation. "
             "You can use ConformerGenerator to add them."
         )
     return X
+
+
+def get_conf_id(mol: Mol) -> int:
+    """
+    Get the conformer ID to use for 3D-based computations. Returns the value of the
+    ``"conf_id"`` property if set, e.g. by ``ConformerGenerator``. Otherwise, returns
+    the ID of the first available conformer, which RDKit sets automatically.
+
+    Assumes that at least one conformation is available. Ensure this by calling
+    require_mols_with_conformations().
+    """
+    if mol.HasProp("conf_id"):
+        return mol.GetIntProp("conf_id")
+    return mol.GetConformer().GetId()
 
 
 def require_strings(X: Sequence[Any]) -> None:

--- a/tests/utils/validators.py
+++ b/tests/utils/validators.py
@@ -5,9 +5,10 @@ from skfp.fingerprints import AtomPairFingerprint
 from skfp.utils.validators import (
     ensure_mols,
     ensure_smiles,
+    get_conf_id,
     require_atoms,
     require_mols,
-    require_mols_with_conf_ids,
+    require_mols_with_conformations,
     require_strings,
 )
 
@@ -78,11 +79,26 @@ def test_require_strings(smiles_list):
         require_strings(smiles_list + [1])
 
 
-def test_require_mols_with_conf_ids(mols_conformers_list, mols_list):
-    require_mols_with_conf_ids(mols_conformers_list)
+def test_require_mols_with_conformations(mols_conformers_list, mols_list):
+    require_mols_with_conformations(mols_conformers_list)
     with pytest.raises(TypeError) as exc_info:
-        require_mols_with_conf_ids(mols_conformers_list + mols_list)
-    assert "each must have conf_id property set" in str(exc_info)
+        require_mols_with_conformations(mols_conformers_list + mols_list)
+    assert "each must have at least one conformation" in str(exc_info)
+
+
+def test_get_conf_id_from_property(mols_conformers_list):
+    for mol in mols_conformers_list:
+        assert get_conf_id(mol) == mol.GetIntProp("conf_id")
+
+
+def test_get_conf_id_defaults_to_first_conformer():
+    from rdkit.Chem import AddHs
+    from rdkit.Chem.AllChem import EmbedMolecule
+
+    mol = AddHs(MolFromSmiles("CCO"))
+    EmbedMolecule(mol, randomSeed=0)
+    assert not mol.HasProp("conf_id")
+    assert get_conf_id(mol) == mol.GetConformer().GetId()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes

Closes https://github.com/MLCIL/scikit-fingerprints/issues/610. Handles conformer ID more robustly, using the default conformer if `conf_id` is not settled, which can be useful when providing them from SDF files or from external programs and libraries.

Technically the degenerate case with 2D-only conformer is allowed, but I don't think this is a problem, as someone would really have to force this edge case.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
