### PR TITLE
Mordred EccentricConnectivityIndex

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -12,6 +12,7 @@ from skfp.fingerprints._new_mordred.descriptors import (
     bond_count,
     carbon_types,
     cpsa,
+    eccentric_connectivity_index,
     extended_topochemical_atom,
     morse,
     polarizability,
@@ -122,6 +123,9 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
         topological_charge.calc(adjacency_matrix_regular, distance_matrix_regular),
         cpsa_2d,
         polarizability.calc(mol_hydrogens),
+        eccentric_connectivity_index.calc(
+            adjacency_matrix_regular, distance_matrix_regular
+        ),
     ]
 
     for values, feature_names in descriptors_2d:

--- a/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
@@ -28,6 +28,6 @@ def calc(
     E = distance_matrix_regular.eccentricities
     D = adjacency_matrix_regular.degree
 
-    value = int((E.astype("int") * D).sum())
+    value = int((E * D).sum())
 
     return np.array([value], dtype=np.float32), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
@@ -28,6 +28,6 @@ def calc(
     E = distance_matrix_regular.eccentricities
     D = adjacency_matrix_regular.degree
 
-    value = int((E * D).sum())
+    value = (E * D).sum()
 
     return np.array([value], dtype=np.float32), FEATURE_NAMES

--- a/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/eccentric_connectivity_index.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from skfp.fingerprints._new_mordred.utils.graph_matrix import (
+    AdjacencyMatrix,
+    DistanceMatrix,
+)
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = ["ECIndex"]
+
+
+def calc(
+    adjacency_matrix_regular: AdjacencyMatrix, distance_matrix_regular: DistanceMatrix
+) -> tuple[np.ndarray, list[str]]:
+    r"""
+    Compute the Mordred eccentric connectivity index descriptor.
+
+    `ECIndex` is defined as :math:`\sum_{i}^{A} E_i D_i`, where :math:`E_i` is the
+    eccentricity of atom :math:`i`, :math:`D_i` is its vertex degree, and :math:`A`
+    is the number of heavy atoms.
+    """
+    E = distance_matrix_regular.eccentricities
+    D = adjacency_matrix_regular.degree
+
+    value = int((E.astype("int") * D).sum())
+
+    return np.array([value], dtype=np.float32), FEATURE_NAMES

--- a/tests/fingerprints/_new_mordred/eccentric_connectivity_index.py
+++ b/tests/fingerprints/_new_mordred/eccentric_connectivity_index.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from skfp.fingerprints._new_mordred.descriptors.eccentric_connectivity_index import (
+    FEATURE_NAMES,
+    calc,
+)
+from skfp.fingerprints._new_mordred.utils.graph_matrix import (
+    AdjacencyMatrix,
+    DistanceMatrix,
+)
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Hexane", [38]),
+        ("Benzene", [36]),
+        ("Caffeine", [137]),
+        ("Cyanidin", [353]),
+        ("Lycopene", [1834]),
+        ("Epicatechin", [353]),
+        ("Limonene", [88]),
+        ("Allicin", [83]),
+        ("Glutathione", [347]),
+        ("Digoxin", [2628]),
+        ("Capsaicin", [515]),
+        ("EllagicAcid", [328]),
+        ("Astaxanthin", [1932]),
+    ],
+)
+def test_eccentric_connectivity_index_values(name, expected, mordred_test_mols):
+    mol_regular = preprocess_mol(mordred_test_mols[name])
+
+    values, feature_names = calc(
+        AdjacencyMatrix(mol_regular), DistanceMatrix(mol_regular)
+    )
+
+    assert feature_names == FEATURE_NAMES
+    assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)

--- a/tests/fingerprints/_new_mordred/eccentric_connectivity_index.py
+++ b/tests/fingerprints/_new_mordred/eccentric_connectivity_index.py
@@ -23,19 +23,19 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 @pytest.mark.parametrize(
     "name, expected",
     [
-        ("Hexane", [38]),
-        ("Benzene", [36]),
-        ("Caffeine", [137]),
-        ("Cyanidin", [353]),
-        ("Lycopene", [1834]),
-        ("Epicatechin", [353]),
-        ("Limonene", [88]),
-        ("Allicin", [83]),
-        ("Glutathione", [347]),
-        ("Digoxin", [2628]),
-        ("Capsaicin", [515]),
-        ("EllagicAcid", [328]),
-        ("Astaxanthin", [1932]),
+        ("Hexane", 38),
+        ("Benzene", 36),
+        ("Caffeine", 137),
+        ("Cyanidin", 353),
+        ("Lycopene", 1834),
+        ("Epicatechin", 353),
+        ("Limonene", 88),
+        ("Allicin", 83),
+        ("Glutathione", 347),
+        ("Digoxin", 2628),
+        ("Capsaicin", 515),
+        ("EllagicAcid", 328),
+        ("Astaxanthin", 1932),
     ],
 )
 def test_eccentric_connectivity_index_values(name, expected, mordred_test_mols):
@@ -46,4 +46,4 @@ def test_eccentric_connectivity_index_values(name, expected, mordred_test_mols):
     )
 
     assert feature_names == FEATURE_NAMES
-    assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)
+    assert_allclose(values, np.float32(expected), rtol=1e-6)

--- a/tests/fingerprints/_new_mordred/topological_index.py
+++ b/tests/fingerprints/_new_mordred/topological_index.py
@@ -3,6 +3,8 @@ import pytest
 from numpy.testing import assert_allclose
 
 from skfp.fingerprints._new_mordred.descriptors import topological_index
+from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
 
 FEATURE_NAMES = ["Diameter", "Radius", "TopoShapeIndex", "PetitjeanIndex"]
 
@@ -20,6 +22,37 @@ FEATURE_NAMES = ["Diameter", "Radius", "TopoShapeIndex", "PetitjeanIndex"]
 )
 def test_topological_index_values(graph_radius, graph_diameter, expected):
     values, feature_names = topological_index.calc(graph_radius, graph_diameter)
+
+    assert feature_names == FEATURE_NAMES
+    assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    # expected in FEATURE_NAMES order: Diameter, Radius, TopoShapeIndex, PetitjeanIndex
+    "name, expected",
+    [
+        ("Hexane", [5, 3, 0.666666667, 0.4]),
+        ("Benzene", [3, 3, 0.0, 0.0]),
+        ("Caffeine", [6, 4, 0.5, 0.333333333]),
+        ("Cyanidin", [10, 5, 1.0, 0.5]),
+        ("Lycopene", [31, 16, 0.9375, 0.483870968]),
+        ("Epicatechin", [10, 5, 1.0, 0.5]),
+        ("Limonene", [6, 3, 1.0, 0.5]),
+        ("Allicin", [7, 4, 0.75, 0.428571429]),
+        ("Glutathione", [12, 6, 1.0, 0.5]),
+        ("Digoxin", [28, 14, 1.0, 0.5]),
+        ("Capsaicin", [15, 8, 0.875, 0.466666667]),
+        ("EllagicAcid", [9, 5, 0.8, 0.444444444]),
+        ("Astaxanthin", [27, 14, 0.928571429, 0.481481481]),
+    ],
+)
+def test_topological_index_reference_values(name, expected, mordred_test_mols):
+    mol_regular = preprocess_mol(mordred_test_mols[name])
+    distance_matrix_regular = DistanceMatrix(mol_regular)
+
+    values, feature_names = topological_index.calc(
+        distance_matrix_regular.radius, distance_matrix_regular.diameter
+    )
 
     assert feature_names == FEATURE_NAMES
     assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)

--- a/tests/fingerprints/_new_mordred/vertex_adjacency_info.py
+++ b/tests/fingerprints/_new_mordred/vertex_adjacency_info.py
@@ -12,12 +12,12 @@ FEATURE_NAMES = ["VAdjMat"]
 @pytest.mark.parametrize(
     "smiles, expected",
     [
-        ("C", [np.nan]),
-        ("CC", [1.0]),
-        ("CCCC", [1 + np.log2(3)]),
-        ("CCO", [1 + np.log2(2)]),
-        ("c1ccccc1", [1 + np.log2(6)]),
-        ("CC(=O)OC1=CC=CC=C1C(=O)O", [1 + np.log2(13)]),
+        ("C", np.nan),
+        ("CC", 1.0),
+        ("CCCC", 1 + np.log2(3)),
+        ("CCO", 1 + np.log2(2)),
+        ("c1ccccc1", 1 + np.log2(6)),
+        ("CC(=O)OC1=CC=CC=C1C(=O)O", 1 + np.log2(13)),
     ],
 )
 def test_vertex_adjacency_info_values(smiles, expected):
@@ -27,4 +27,4 @@ def test_vertex_adjacency_info_values(smiles, expected):
     values, feature_names = vertex_adjacency_info.calc(mol_regular)
 
     assert feature_names == FEATURE_NAMES
-    assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)
+    assert_allclose(values, np.float32(expected), rtol=1e-6)

--- a/tests/fingerprints/_new_mordred/wiener_index.py
+++ b/tests/fingerprints/_new_mordred/wiener_index.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from skfp.fingerprints._new_mordred.descriptors.wiener_index import (
+    FEATURE_NAMES,
+    calc,
+)
+from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Hexane", [35, 3]),
+        ("Benzene", [27, 3]),
+        ("Caffeine", [258, 25]),
+        ("Cyanidin", [894, 36]),
+        ("Lycopene", [8904, 43]),
+        ("Epicatechin", [894, 36]),
+        ("Limonene", [120, 11]),
+        ("Allicin", [108, 7]),
+        ("Glutathione", [969, 24]),
+        ("Digoxin", [14940, 113]),
+        ("Capsaicin", [1411, 26]),
+        ("EllagicAcid", [851, 48]),
+        ("Astaxanthin", [10234, 69]),
+    ],
+)
+def test_wiener_index_values(name, expected, mordred_test_mols):
+    mol_regular = preprocess_mol(mordred_test_mols[name])
+    distance_matrix_regular = DistanceMatrix(mol_regular)
+
+    values, feature_names = calc(mol_regular, distance_matrix_regular)
+
+    assert feature_names == FEATURE_NAMES
+    assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-6)

--- a/tests/fingerprints/_new_mordred/zagreb_index.py
+++ b/tests/fingerprints/_new_mordred/zagreb_index.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from skfp.fingerprints._new_mordred.descriptors.zagreb_index import (
+    FEATURE_NAMES,
+    calc,
+)
+from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+
+@pytest.mark.parametrize(
+    "name, expected_zagreb1",
+    [
+        ("Hexane", 18),
+        ("Benzene", 24),
+        ("Caffeine", 76),
+        ("Cyanidin", 114),
+        ("Lycopene", 170),
+        ("Epicatechin", 114),
+        ("Limonene", 46),
+        ("Allicin", 32),
+        ("Glutathione", 86),
+        ("Digoxin", 320),
+        ("Capsaicin", 98),
+        ("EllagicAcid", 130),
+        ("Astaxanthin", 218),
+    ],
+)
+def test_zagreb1_values(name, expected_zagreb1, mordred_test_mols):
+    mol_regular = preprocess_mol(mordred_test_mols[name])
+    adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
+
+    values, feature_names = calc(mol_regular, adjacency_matrix_regular)
+
+    assert feature_names == FEATURE_NAMES
+    assert_allclose(values[0], np.float32(expected_zagreb1), rtol=1e-6)
+
+
+def test_zagreb_all_features(mordred_test_mols):
+    # full reference vector [Zagreb1, Zagreb2, mZagreb1, mZagreb2]
+    expected = [18, 19, 1.61, 0.92]
+
+    mol_regular = preprocess_mol(mordred_test_mols["MethylCyclopropane"])
+    adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
+
+    values, feature_names = calc(mol_regular, adjacency_matrix_regular)
+
+    assert feature_names == FEATURE_NAMES
+    assert_allclose(values, np.asarray(expected, dtype=np.float32), atol=1e-2)


### PR DESCRIPTION
## Changes

Adds the eccentric connectivity index and improves tests for topological, Wiener, and Zagreb indices.

## Checklist before requesting a review
- [x] Docstrings added/updated in public functions and classes
- [x] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [x] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
