### PR TITLE
Add element_counts descriptor (closes #551)

### DIFF
--- a/docs/modules/descriptors.rst
+++ b/docs/modules/descriptors.rst
@@ -27,6 +27,7 @@ Constitutional descriptors (based on atomic composition):
     average_molecular_weight
     bond_count
     element_atom_count
+    element_counts
     heavy_atom_count
     molecular_weight
     number_of_rings

--- a/skfp/descriptors/__init__.py
+++ b/skfp/descriptors/__init__.py
@@ -3,6 +3,7 @@ from .constitutional import (
     average_molecular_weight,
     bond_count,
     element_atom_count,
+    element_counts,
     heavy_atom_count,
     molecular_weight,
     number_of_rings,

--- a/skfp/descriptors/constitutional.py
+++ b/skfp/descriptors/constitutional.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rdkit.Chem import Mol
 from rdkit.Chem.Descriptors import MolWt
 from rdkit.Chem.rdMolDescriptors import CalcNumRings, CalcNumRotatableBonds
@@ -115,6 +116,47 @@ def element_atom_count(mol: Mol, atom_id: int | str) -> int:
             for atom in mol.GetAtoms()
             if atom.GetAtomicNum() == atom_id or atom.GetSymbol() == atom_id
         )
+
+
+def element_counts(mol: Mol) -> np.ndarray:
+    """
+    Element counts.
+
+    Calculates the number of atoms of every chemical element, returned as a
+    vector indexed by atomic number. Position ``i`` holds the count of the
+    element with atomic number ``i + 1`` (e.g. index 0 is hydrogen, index 5
+    is carbon). The vector has length 118, covering all elements of the RDKit
+    periodic table. Hydrogens are counted in total, including both explicit and
+    implicit ones, consistently with :func:`element_atom_count`.
+
+    Parameters
+    ----------
+    mol : RDKit ``Mol`` object
+        The molecule for which the element counts are to be calculated.
+
+    Examples
+    --------
+    >>> from rdkit.Chem import MolFromSmiles
+    >>> from skfp.descriptors import element_counts
+    >>> mol = MolFromSmiles("C1=CC=CC=C1")  # Benzene
+    >>> counts = element_counts(mol)
+    >>> int(counts[5])  # carbon, atomic number 6
+    6
+    >>> int(counts[0])  # hydrogen
+    6
+
+    >>> mol = MolFromSmiles("CCO")  # Ethanol
+    >>> counts = element_counts(mol)
+    >>> int(counts[5]), int(counts[7]), int(counts[0])  # carbon, oxygen, hydrogen
+    (2, 1, 6)
+    """
+    counts = np.zeros(118, dtype=int)
+    for atom in mol.GetAtoms():
+        atomic_num = atom.GetAtomicNum()
+        if atomic_num != 1:
+            counts[atomic_num - 1] += 1
+    counts[0] = element_atom_count(mol, 1)
+    return counts
 
 
 def heavy_atom_count(mol: Mol) -> int:

--- a/tests/descriptors/constitutional.py
+++ b/tests/descriptors/constitutional.py
@@ -95,6 +95,41 @@ def test_element_atom_count(mol_name, atom_id, expected_value, input_mols):
 
 
 @pytest.mark.parametrize(
+    "mol_name, atomic_number, expected_value",
+    [
+        ("benzene", 6, 6),
+        ("benzene", 1, 6),
+        ("ethanol", 6, 2),
+        ("ethanol", 8, 1),
+        ("ethanol", 1, 6),
+        ("propane", 1, 8),
+        ("hydrogen_cyanide", 7, 1),
+        ("oxygen", 8, 1),
+        ("oxygen", 1, 2),
+    ],
+)
+def test_element_counts(mol_name, atomic_number, expected_value, input_mols):
+    mol = input_mols[mol_name]
+    result = const.element_counts(mol)
+    assert len(result) == 118
+    assert_equal(result[atomic_number - 1], expected_value)
+
+
+def test_element_counts_matches_element_atom_count(input_mols):
+    for mol in input_mols.values():
+        counts = const.element_counts(mol)
+        assert_equal(counts[5], const.element_atom_count(mol, "C"))
+        assert_equal(counts[0], const.element_atom_count(mol, "H"))
+
+
+def test_element_counts_absent_elements_are_zero(input_mols):
+    # benzene contains only carbon and hydrogen
+    counts = const.element_counts(input_mols["benzene"])
+    assert_equal(counts[7], 0)  # oxygen absent
+    assert_equal(counts.sum(), 12)  # 6 C + 6 H
+
+
+@pytest.mark.parametrize(
     "mol_name, expected_value",
     [
         ("benzene", 6),


### PR DESCRIPTION
Closes #551.

## Summary

Adds `element_counts(mol)` to `skfp.descriptors.constitutional`, returning a vector of atom counts across all elements of the RDKit periodic table — useful as fingerprint features or for composition analysis, as requested in #551.

## Details

- Returns a length-118 `np.ndarray` indexed by atomic number: position `i` holds the count of the element with atomic number `i + 1` (index 0 = hydrogen, index 5 = carbon, …).
- Hydrogens are counted in total (explicit + implicit), **consistently with the existing `element_atom_count`** — the H bucket is filled by delegating to `element_atom_count(mol, 1)`, so the two functions never disagree.
- Exported from `skfp.descriptors`, added to `docs/modules/descriptors.rst`, and covered by parametrized tests (per-element counts, consistency with `element_atom_count`, absent-element zeros and total sum).

```python
>>> from rdkit.Chem import MolFromSmiles
>>> from skfp.descriptors import element_counts
>>> counts = element_counts(MolFromSmiles("CCO"))  # ethanol
>>> int(counts[5]), int(counts[7]), int(counts[0])  # C, O, H
(2, 1, 6)
```

## Notes

- Doctests use `int(counts[i])` because NumPy 2.x scalars repr as `np.int64(6)`; wrapping keeps the doctest output stable across NumPy versions.
- Happy to switch the return type to a dict keyed by symbol/atomic number instead of a fixed-length vector if you prefer that API — the issue said "vector", so I went literal.